### PR TITLE
fixes to match error reporting improvements in GRHayL

### DIFF
--- a/GRHayLHD/src/Hybrid/conservs_to_prims.c
+++ b/GRHayLHD/src/Hybrid/conservs_to_prims.c
@@ -78,7 +78,7 @@ void GRHayLHD_hybrid_conservs_to_prims(CCTK_ARGUMENTS) {
         cons.SD[1] = Stildey[index];
         cons.SD[2] = Stildez[index];
 
-        int check;
+        ghl_error_codes_t error;
 
         /************* Main conservative-to-primitive logic ************/
         if(cons.rho>0.0) {
@@ -87,21 +87,21 @@ void GRHayLHD_hybrid_conservs_to_prims(CCTK_ARGUMENTS) {
               &prims, &cons, &diagnostics);
 
           ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
-
-          /************* Conservative-to-primitive recovery ************/
-          check = ghl_con2prim_multi_method(
+          error = ghl_con2prim_multi_method(
                 ghl_params, ghl_eos, &ADM_metric, &metric_aux,
                 &cons_undens, &prims, &diagnostics);
+
+          if(isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]))
+            error = ghl_error_c2p_singular;
         } else {
+          ghl_set_prims_to_constant_atm(ghl_eos, &prims);
           local_failure_checker += 1;
           rho_star_fix_applied++;
-          ghl_set_prims_to_constant_atm(ghl_eos, &prims);
-          check = 0;
+          error = ghl_success;
         }
 
-        if(check || isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2])) {
+        if(error) {
           pointcount_avg++;
-          check = 1;
 
           // Reload cons for consistency (hybrid applies limits to cons)
           cons.rho   = rho_star[index];
@@ -145,8 +145,7 @@ void GRHayLHD_hybrid_conservs_to_prims(CCTK_ARGUMENTS) {
           }
 
           int avg_weight = 1;
-          while(check && avg_weight < 5) {
-            check = 0;
+          while(error && avg_weight < 5) {
             // last point doesn't add central point and has 1 less point
             // being averaged.
             n_avg += (avg_weight!=4);
@@ -168,15 +167,15 @@ void GRHayLHD_hybrid_conservs_to_prims(CCTK_ARGUMENTS) {
             ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons_avg, &cons_undens);
 
             /************* Conservative-to-primitive recovery ************/
-            check = ghl_con2prim_multi_method(
+            error = ghl_con2prim_multi_method(
                   ghl_params, ghl_eos, &ADM_metric, &metric_aux,
                   &cons_undens, &prims, &diagnostics);
 
             avg_weight++;
             if(isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]) )
-              check = 1;
+              error = ghl_error_c2p_singular;
           }
-          if(check) {
+          if(error) {
             // We are still failing after exhausting the averaging options.
             // Next, we try Font1D.
             pointcount_Font++;
@@ -187,14 +186,14 @@ void GRHayLHD_hybrid_conservs_to_prims(CCTK_ARGUMENTS) {
 
             ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
 
-            check = ghl_hybrid_Font1D(
+            error = ghl_hybrid_Font1D(
                   ghl_params, ghl_eos, &ADM_metric, &metric_aux,
                   &cons_undens, &prims, &diagnostics);
 
             if(isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]) )
-              check = 1;
+              error = ghl_error_c2p_singular;
 
-            if(check) {
+            if(error) {
               // We are still failing after exhausting the averaging options.
               // We'll surrender and resort to atmospheric reset...
 
@@ -206,18 +205,6 @@ void GRHayLHD_hybrid_conservs_to_prims(CCTK_ARGUMENTS) {
                 failures_inhoriz++;
                 pointcount_inhoriz++;
               }
-              CCTK_VINFO("***********************************************************\n"
-                         "Con2Prim and averaging backups failed! Resetting to atmosphere...\n"
-                         "position = %e %e %e\n"
-                         "lapse, shift = %e, %e, %e, %e\n"
-                         "gij = %e, %e, %e, %e, %e, %e\n"
-                         "rho_*, ~tau, ~S_{i}: %e, %e, %e, %e, %e\n"
-                         "***********************************************************",
-                         x[index], y[index], z[index],
-                         ADM_metric.lapse, ADM_metric.betaU[0], ADM_metric.betaU[1], ADM_metric.betaU[2],
-                         ADM_metric.gammaDD[0][0], ADM_metric.gammaDD[0][1], ADM_metric.gammaDD[0][2],
-                         ADM_metric.gammaDD[1][1], ADM_metric.gammaDD[1][2], ADM_metric.gammaDD[2][2],
-                         cons.rho, cons.tau, cons.SD[0], cons.SD[1], cons.SD[2]);
             } // atmospheric backup
           } // Font1D backup
         } // if c2p failed
@@ -227,8 +214,10 @@ void GRHayLHD_hybrid_conservs_to_prims(CCTK_ARGUMENTS) {
         //---------- Primitive recovery succeeded ----------
         //--------------------------------------------------
         // Enforce limits on primitive variables and recompute conservatives.
-        diagnostics.speed_limited += ghl_enforce_primitive_limits_and_compute_u0(
-              ghl_params, ghl_eos, &ADM_metric, &prims);
+        error = ghl_enforce_primitive_limits_and_compute_u0(
+              ghl_params, ghl_eos, &ADM_metric, &prims, &diagnostics.speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
 
         rho[index]   = prims.rho;
         press[index] = prims.press;

--- a/GRHayLHD/src/Hybrid/evaluate_fluxes_rhs.c
+++ b/GRHayLHD/src/Hybrid/evaluate_fluxes_rhs.c
@@ -109,8 +109,13 @@ void GRHayLHD_hybrid_evaluate_fluxes_rhs(CCTK_ARGUMENTS) {
           prims_r.BU[0] = prims_r.BU[1] = prims_r.BU[2] = 0.0;
           prims_l.BU[0] = prims_l.BU[1] = prims_l.BU[2] = 0.0;
 
-          int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r);
-          speed_limited = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l);
+          bool speed_limited;
+          ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
+          if(error)
+            ghl_read_error_codes(error);
+          error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
+          if(error)
+            ghl_read_error_codes(error);
 
           CCTK_REAL cmin, cmax;
           ghl_conservative_quantities cons_fluxes;

--- a/GRHayLHD/src/Hybrid/evaluate_sources_rhs.c
+++ b/GRHayLHD/src/Hybrid/evaluate_sources_rhs.c
@@ -45,8 +45,10 @@ void GRHayLHD_hybrid_evaluate_sources_rhs(CCTK_ARGUMENTS) {
         prims.vU[1] = vy[index];
         prims.vU[2] = vz[index];
 
-        const int speed_limited CCTK_ATTRIBUTE_UNUSED =
-              ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims);
+        bool speed_limited;
+        ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
 
         ghl_metric_quantities ADM_metric_derivs_x;
         GRHayLHD_compute_metric_derivs(

--- a/GRHayLHD/src/Hybrid/outer_boundaries.c
+++ b/GRHayLHD/src/Hybrid/outer_boundaries.c
@@ -189,10 +189,13 @@ void GRHayLHD_hybrid_enforce_primitive_limits_and_compute_conservs(const cGH* cc
   ghl_ADM_aux_quantities metric_aux;
   ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
 
-  ghl_conservative_quantities cons;
-  const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_enforce_primitive_limits_and_compute_u0(
-        ghl_params, ghl_eos, &ADM_metric, prims);
+  bool speed_limited;
+  ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
+        ghl_params, ghl_eos, &ADM_metric, prims, &speed_limited);
+  if(error)
+    ghl_read_error_codes(error);
 
+  ghl_conservative_quantities cons;
   ghl_compute_conservs(
         &ADM_metric, &metric_aux, prims, &cons);
 

--- a/GRHayLHD/src/Hybrid/prims_to_conservs.c
+++ b/GRHayLHD/src/Hybrid/prims_to_conservs.c
@@ -33,9 +33,13 @@ void GRHayLHD_hybrid_prims_to_conservs(CCTK_ARGUMENTS) {
         prims.vU[1] = vy[index];
         prims.vU[2] = vz[index];
 
+        bool speed_limited; 
+        const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
+              ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
+
         ghl_conservative_quantities cons;
-        const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_enforce_primitive_limits_and_compute_u0(
-              ghl_params, ghl_eos, &ADM_metric, &prims);
         ghl_compute_conservs(
               &ADM_metric, &metric_aux, &prims, &cons);
 

--- a/GRHayLHD/src/HybridEntropy/evaluate_fluxes_rhs.c
+++ b/GRHayLHD/src/HybridEntropy/evaluate_fluxes_rhs.c
@@ -112,8 +112,13 @@ void GRHayLHD_hybrid_entropy_evaluate_fluxes_rhs(CCTK_ARGUMENTS) {
           prims_r.BU[0] = prims_r.BU[1] = prims_r.BU[2] = 0.0;
           prims_l.BU[0] = prims_l.BU[1] = prims_l.BU[2] = 0.0;
 
-          int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r);
-          speed_limited = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l);
+          bool speed_limited;
+          ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
+          if(error)
+            ghl_read_error_codes(error);
+          error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
+          if(error)
+            ghl_read_error_codes(error);
 
           CCTK_REAL cmin, cmax;
           ghl_conservative_quantities cons_fluxes;

--- a/GRHayLHD/src/HybridEntropy/evaluate_sources_rhs.c
+++ b/GRHayLHD/src/HybridEntropy/evaluate_sources_rhs.c
@@ -47,8 +47,10 @@ void GRHayLHD_hybrid_entropy_evaluate_sources_rhs(CCTK_ARGUMENTS) {
         prims.vU[2] = vz[index];
         prims.entropy = entropy[index];
 
-        const int speed_limited CCTK_ATTRIBUTE_UNUSED =
-              ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims);
+        bool speed_limited;
+        ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
 
         ghl_metric_quantities ADM_metric_derivs_x;
         GRHayLHD_compute_metric_derivs(

--- a/GRHayLHD/src/HybridEntropy/outer_boundaries.c
+++ b/GRHayLHD/src/HybridEntropy/outer_boundaries.c
@@ -195,10 +195,13 @@ void GRHayLHD_hybrid_entropy_enforce_primitive_limits_and_compute_conservs(const
   ghl_ADM_aux_quantities metric_aux;
   ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
 
-  ghl_conservative_quantities cons;
-  const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_enforce_primitive_limits_and_compute_u0(
-        ghl_params, ghl_eos, &ADM_metric, prims);
+  bool speed_limited;
+  ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
+        ghl_params, ghl_eos, &ADM_metric, prims, &speed_limited);
+  if(error)
+    ghl_read_error_codes(error);
 
+  ghl_conservative_quantities cons;
   ghl_compute_conservs(
         &ADM_metric, &metric_aux, prims, &cons);
 

--- a/GRHayLHD/src/HybridEntropy/prims_to_conservs.c
+++ b/GRHayLHD/src/HybridEntropy/prims_to_conservs.c
@@ -34,9 +34,13 @@ void GRHayLHD_hybrid_entropy_prims_to_conservs(CCTK_ARGUMENTS) {
         prims.vU[2]   = vz[index];
         prims.entropy = entropy[index];
 
+        bool speed_limited; 
+        const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
+              ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
+
         ghl_conservative_quantities cons;
-        const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_enforce_primitive_limits_and_compute_u0(
-              ghl_params, ghl_eos, &ADM_metric, &prims);
         ghl_compute_conservs(
               &ADM_metric, &metric_aux, &prims, &cons);
 

--- a/GRHayLHD/src/Tabulated/conservs_to_prims.c
+++ b/GRHayLHD/src/Tabulated/conservs_to_prims.c
@@ -79,27 +79,27 @@ void GRHayLHD_tabulated_conservs_to_prims(CCTK_ARGUMENTS) {
         cons.SD[2] = Stildez[index];
         cons.Y_e   = Ye_star[index];
 
-        int check;
+        ghl_error_codes_t error;
 
         /************* Main conservative-to-primitive logic ************/
         if(cons.rho>0.0) {
           ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
-
-          /************* Conservative-to-primitive recovery ************/
-          check = ghl_con2prim_multi_method(
+          error = ghl_con2prim_multi_method(
                 ghl_params, ghl_eos, &ADM_metric, &metric_aux,
                 &cons_undens, &prims, &diagnostics);
+
+          if(isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]*
+                   prims.Y_e*prims.temperature))
+            error = ghl_error_c2p_singular;
         } else {
+          ghl_set_prims_to_constant_atm(ghl_eos, &prims);
           local_failure_checker += 1;
           rho_star_fix_applied++;
-          ghl_set_prims_to_constant_atm(ghl_eos, &prims);
-          check = 0;
+          error = ghl_success;
         }
 
-        if(check || isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]*
-                          prims.Y_e*prims.temperature)) {
+        if(error) {
           pointcount_avg++;
-          check = 1;
 
           ghl_conservative_quantities cons_neigh_avg, cons_avg;
           cons_neigh_avg.rho   = 0.0;
@@ -138,8 +138,7 @@ void GRHayLHD_tabulated_conservs_to_prims(CCTK_ARGUMENTS) {
           }
 
           int avg_weight = 1;
-          while(check && avg_weight < 5) {
-            check = 0;
+          while(error && avg_weight < 5) {
             // last point doesn't add central point and has 1 less point
             // being averaged.
             n_avg += (avg_weight!=4);
@@ -163,16 +162,16 @@ void GRHayLHD_tabulated_conservs_to_prims(CCTK_ARGUMENTS) {
             ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons_avg, &cons_undens);
 
             /************* Conservative-to-primitive recovery ************/
-            check = ghl_con2prim_multi_method(
+            error = ghl_con2prim_multi_method(
                   ghl_params, ghl_eos, &ADM_metric, &metric_aux,
                   &cons_undens, &prims, &diagnostics);
 
             avg_weight++;
             if(isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]*
                      prims.Y_e*prims.temperature) )
-              check = 1;
+              error = ghl_error_c2p_singular;
           }
-          if(check) {
+          if(error) {
             // We are still failing after exhausting the averaging options.
             // We'll surrender and resort to atmospheric reset...
 
@@ -185,20 +184,6 @@ void GRHayLHD_tabulated_conservs_to_prims(CCTK_ARGUMENTS) {
               failures_inhoriz++;
               pointcount_inhoriz++;
             }
-            CCTK_VINFO("***********************************************************\n"
-                       "Con2Prim and averaging backups failed! Resetting to atmosphere...\n"
-                       "position = %e %e %e\n"
-                       "lapse, shift = %e, %e, %e, %e\n"
-                       "gij = %e, %e, %e, %e, %e, %e\n"
-                       "rho_*, ~tau, ~S_{i}: %e, %e, %e, %e, %e\n"
-                       "~DYe: %e\n"
-                       "***********************************************************",
-                       x[index], y[index], z[index],
-                       ADM_metric.lapse, ADM_metric.betaU[0], ADM_metric.betaU[1], ADM_metric.betaU[2],
-                       ADM_metric.gammaDD[0][0], ADM_metric.gammaDD[0][1], ADM_metric.gammaDD[0][2],
-                       ADM_metric.gammaDD[1][1], ADM_metric.gammaDD[1][2], ADM_metric.gammaDD[2][2],
-                       cons.rho, cons.tau, cons.SD[0], cons.SD[1], cons.SD[2],
-                       cons.Y_e);
           } // atmospheric backup
         } // if c2p failed
         /***************************************************************/
@@ -207,8 +192,10 @@ void GRHayLHD_tabulated_conservs_to_prims(CCTK_ARGUMENTS) {
         //---------- Primitive recovery succeeded ----------
         //--------------------------------------------------
         // Enforce limits on primitive variables and recompute conservatives.
-        diagnostics.speed_limited += ghl_enforce_primitive_limits_and_compute_u0(
-              ghl_params, ghl_eos, &ADM_metric, &prims);
+        error = ghl_enforce_primitive_limits_and_compute_u0(
+              ghl_params, ghl_eos, &ADM_metric, &prims, &diagnostics.speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
 
         rho[index]         = prims.rho;
         press[index]       = prims.press;

--- a/GRHayLHD/src/Tabulated/evaluate_fluxes_rhs.c
+++ b/GRHayLHD/src/Tabulated/evaluate_fluxes_rhs.c
@@ -104,8 +104,13 @@ void GRHayLHD_tabulated_evaluate_fluxes_rhs(CCTK_ARGUMENTS) {
 
           prims_r.temperature = prims_l.temperature = temperature[index];
 
-          int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r);
-          speed_limited = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l);
+          bool speed_limited;
+          ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
+          if(error)
+            ghl_read_error_codes(error);
+          error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
+          if(error)
+            ghl_read_error_codes(error);
 
           // We must now compute eps and T
           ghl_tabulated_enforce_bounds_rho_Ye_P(ghl_eos, &prims_r.rho, &prims_r.Y_e, &prims_r.press);

--- a/GRHayLHD/src/Tabulated/evaluate_sources_rhs.c
+++ b/GRHayLHD/src/Tabulated/evaluate_sources_rhs.c
@@ -48,8 +48,10 @@ void GRHayLHD_tabulated_evaluate_sources_rhs(CCTK_ARGUMENTS) {
         prims.Y_e         = Y_e[index];
         prims.temperature = temperature[index];
 
-        const int speed_limited CCTK_ATTRIBUTE_UNUSED =
-              ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims);
+        bool speed_limited;
+        ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
 
         ghl_metric_quantities ADM_metric_derivs_x;
         GRHayLHD_compute_metric_derivs(

--- a/GRHayLHD/src/Tabulated/outer_boundaries.c
+++ b/GRHayLHD/src/Tabulated/outer_boundaries.c
@@ -201,10 +201,13 @@ void GRHayLHD_tabulated_enforce_primitive_limits_and_compute_conservs(const cGH*
   ghl_ADM_aux_quantities metric_aux;
   ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
 
-  ghl_conservative_quantities cons;
-  const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_enforce_primitive_limits_and_compute_u0(
-        ghl_params, ghl_eos, &ADM_metric, prims);
+  bool speed_limited;
+  ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
+        ghl_params, ghl_eos, &ADM_metric, prims, &speed_limited);
+  if(error)
+    ghl_read_error_codes(error);
 
+  ghl_conservative_quantities cons;
   ghl_compute_conservs(
         &ADM_metric, &metric_aux, prims, &cons);
 

--- a/GRHayLHD/src/Tabulated/prims_to_conservs.c
+++ b/GRHayLHD/src/Tabulated/prims_to_conservs.c
@@ -35,9 +35,13 @@ void GRHayLHD_tabulated_prims_to_conservs(CCTK_ARGUMENTS) {
         prims.Y_e         = Y_e[index];
         prims.temperature = temperature[index];
 
+        bool speed_limited; 
+        const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
+              ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
+
         ghl_conservative_quantities cons;
-        const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_enforce_primitive_limits_and_compute_u0(
-              ghl_params, ghl_eos, &ADM_metric, &prims);
         ghl_compute_conservs(
               &ADM_metric, &metric_aux, &prims, &cons);
 

--- a/GRHayLHD/src/TabulatedEntropy/conservs_to_prims.c
+++ b/GRHayLHD/src/TabulatedEntropy/conservs_to_prims.c
@@ -81,27 +81,27 @@ void GRHayLHD_tabulated_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
         cons.entropy = ent_star[index];
         cons.Y_e     = Ye_star[index];
 
-        int check;
+        ghl_error_codes_t error;
 
         /************* Main conservative-to-primitive logic ************/
         if(cons.rho>0.0) {
           ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
-
-          /************* Conservative-to-primitive recovery ************/
-          check = ghl_con2prim_multi_method(
+          error = ghl_con2prim_multi_method(
                 ghl_params, ghl_eos, &ADM_metric, &metric_aux,
                 &cons_undens, &prims, &diagnostics);
+
+          if(isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]*
+                   prims.entropy*prims.Y_e*prims.temperature))
+            error = ghl_error_c2p_singular;
         } else {
+          ghl_set_prims_to_constant_atm(ghl_eos, &prims);
           local_failure_checker += 1;
           rho_star_fix_applied++;
-          ghl_set_prims_to_constant_atm(ghl_eos, &prims);
-          check = 0;
+          error = ghl_success;
         }
 
-        if(check || isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]*
-                          prims.entropy*prims.Y_e*prims.temperature)) {
+        if(error) {
           pointcount_avg++;
-          check = 1;
 
           ghl_conservative_quantities cons_neigh_avg, cons_avg;
           cons_neigh_avg.rho     = 0.0;
@@ -142,8 +142,7 @@ void GRHayLHD_tabulated_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
           }
 
           int avg_weight = 1;
-          while(check && avg_weight < 5) {
-            check = 0;
+          while(error && avg_weight < 5) {
             // last point doesn't add central point and has 1 less point
             // being averaged.
             n_avg += (avg_weight!=4);
@@ -169,16 +168,16 @@ void GRHayLHD_tabulated_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
             ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons_avg, &cons_undens);
 
             /************* Conservative-to-primitive recovery ************/
-            check = ghl_con2prim_multi_method(
+            error = ghl_con2prim_multi_method(
                   ghl_params, ghl_eos, &ADM_metric, &metric_aux,
                   &cons_undens, &prims, &diagnostics);
 
             avg_weight++;
             if(isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]*
                      prims.entropy*prims.Y_e*prims.temperature) )
-              check = 1;
+              error = ghl_error_c2p_singular;
           }
-          if(check) {
+          if(error) {
             // We are still failing after exhausting the averaging options.
             // We'll surrender and resort to atmospheric reset...
 
@@ -191,20 +190,6 @@ void GRHayLHD_tabulated_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
               failures_inhoriz++;
               pointcount_inhoriz++;
             }
-            CCTK_VINFO("***********************************************************\n"
-                       "Con2Prim and averaging backups failed! Resetting to atmosphere...\n"
-                       "position = %e %e %e\n"
-                       "lapse, shift = %e, %e, %e, %e\n"
-                       "gij = %e, %e, %e, %e, %e, %e\n"
-                       "rho_*, ~tau, ~S_{i}: %e, %e, %e, %e, %e\n"
-                       "~DS, ~DYe: %e, %e\n"
-                       "***********************************************************",
-                       x[index], y[index], z[index],
-                       ADM_metric.lapse, ADM_metric.betaU[0], ADM_metric.betaU[1], ADM_metric.betaU[2],
-                       ADM_metric.gammaDD[0][0], ADM_metric.gammaDD[0][1], ADM_metric.gammaDD[0][2],
-                       ADM_metric.gammaDD[1][1], ADM_metric.gammaDD[1][2], ADM_metric.gammaDD[2][2],
-                       cons.rho, cons.tau, cons.SD[0], cons.SD[1], cons.SD[2],
-                       cons.entropy, cons.Y_e);
           } // atmospheric backup
         } // if c2p failed
         /***************************************************************/
@@ -213,8 +198,10 @@ void GRHayLHD_tabulated_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
         //---------- Primitive recovery succeeded ----------
         //--------------------------------------------------
         // Enforce limits on primitive variables and recompute conservatives.
-        diagnostics.speed_limited += ghl_enforce_primitive_limits_and_compute_u0(
-              ghl_params, ghl_eos, &ADM_metric, &prims);
+        error = ghl_enforce_primitive_limits_and_compute_u0(
+              ghl_params, ghl_eos, &ADM_metric, &prims, &diagnostics.speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
 
         rho[index]         = prims.rho;
         press[index]       = prims.press;

--- a/GRHayLHD/src/TabulatedEntropy/evaluate_fluxes_rhs.c
+++ b/GRHayLHD/src/TabulatedEntropy/evaluate_fluxes_rhs.c
@@ -106,8 +106,13 @@ void GRHayLHD_tabulated_entropy_evaluate_fluxes_rhs(CCTK_ARGUMENTS) {
 
           prims_r.temperature = prims_l.temperature = temperature[index];
 
-          int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r);
-          speed_limited = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l);
+          bool speed_limited;
+          ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
+          if(error)
+            ghl_read_error_codes(error);
+          error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
+          if(error)
+            ghl_read_error_codes(error);
 
           // We must now compute eps and T
           ghl_tabulated_enforce_bounds_rho_Ye_P(ghl_eos, &prims_r.rho, &prims_r.Y_e, &prims_r.press);

--- a/GRHayLHD/src/TabulatedEntropy/evaluate_sources_rhs.c
+++ b/GRHayLHD/src/TabulatedEntropy/evaluate_sources_rhs.c
@@ -50,8 +50,10 @@ void GRHayLHD_tabulated_entropy_evaluate_sources_rhs(CCTK_ARGUMENTS) {
         prims.Y_e         = Y_e[index];
         prims.temperature = temperature[index];
 
-        const int speed_limited CCTK_ATTRIBUTE_UNUSED =
-              ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims);
+        bool speed_limited;
+        ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
 
         ghl_metric_quantities ADM_metric_derivs_x;
         GRHayLHD_compute_metric_derivs(

--- a/GRHayLHD/src/TabulatedEntropy/outer_boundaries.c
+++ b/GRHayLHD/src/TabulatedEntropy/outer_boundaries.c
@@ -207,10 +207,13 @@ void GRHayLHD_tabulated_entropy_enforce_primitive_limits_and_compute_conservs(co
   ghl_ADM_aux_quantities metric_aux;
   ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
 
-  ghl_conservative_quantities cons;
-  const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_enforce_primitive_limits_and_compute_u0(
-        ghl_params, ghl_eos, &ADM_metric, prims);
+  bool speed_limited;
+  ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
+        ghl_params, ghl_eos, &ADM_metric, prims, &speed_limited);
+  if(error)
+    ghl_read_error_codes(error);
 
+  ghl_conservative_quantities cons;
   ghl_compute_conservs(
         &ADM_metric, &metric_aux, prims, &cons);
 

--- a/GRHayLHD/src/TabulatedEntropy/prims_to_conservs.c
+++ b/GRHayLHD/src/TabulatedEntropy/prims_to_conservs.c
@@ -36,9 +36,13 @@ void GRHayLHD_tabulated_entropy_prims_to_conservs(CCTK_ARGUMENTS) {
         prims.Y_e         = Y_e[index];
         prims.temperature = temperature[index];
 
+        bool speed_limited; 
+        const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
+              ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
+
         ghl_conservative_quantities cons;
-        const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_enforce_primitive_limits_and_compute_u0(
-              ghl_params, ghl_eos, &ADM_metric, &prims);
         ghl_compute_conservs(
               &ADM_metric, &metric_aux, &prims, &cons);
 

--- a/GRHayLHDX/src/Hybrid/conservs_to_prims.cxx
+++ b/GRHayLHDX/src/Hybrid/conservs_to_prims.cxx
@@ -60,7 +60,7 @@ extern "C" void GRHayLHDX_hybrid_conservs_to_prims(CCTK_ARGUMENTS) {
     cons.SD[1] = Stildey(index);
     cons.SD[2] = Stildez(index);
 
-    int check;
+    ghl_error_codes_t error;
 
     cons_orig = cons;
 
@@ -71,38 +71,40 @@ extern "C" void GRHayLHDX_hybrid_conservs_to_prims(CCTK_ARGUMENTS) {
             &prims, &cons, &diagnostics);
 
       ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
-
-      /************* Conservative-to-primitive recovery ************/
-      check = ghl_con2prim_multi_method(
+      error = ghl_con2prim_multi_method(
             ghl_params, ghl_eos, &ADM_metric, &metric_aux,
             &cons_undens, &prims, &diagnostics);
+
+      if(isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]))
+        error = ghl_error_c2p_singular;
     } else {
+      ghl_set_prims_to_constant_atm(ghl_eos, &prims);
       local_failure_checker += 1;
       //rho_star_fix_applied++;
-      ghl_set_prims_to_constant_atm(ghl_eos, &prims);
-      check = 0;
+      error = ghl_success;
     }
 
-    //Add averaging here
-    if(check || isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2])) {
+    //TODO: Add averaging here
+    if(error) {
       // We are still failing after exhausting the averaging options.
       // Next, we try Font1D.
 
-      ghl_apply_conservative_limits(
-          ghl_params, ghl_eos, &ADM_metric,
-          &prims, &cons, &diagnostics);
+      // This part is only needed once the averaging part is present
+      //ghl_apply_conservative_limits(
+      //    ghl_params, ghl_eos, &ADM_metric,
+      //    &prims, &cons, &diagnostics);
 
-      ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
+      //ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
 
-      check = ghl_hybrid_Font1D(
+      error = ghl_hybrid_Font1D(
             ghl_params, ghl_eos, &ADM_metric, &metric_aux,
             &cons_undens, &prims, &diagnostics);
 
       if(isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]*
                prims.entropy) )
-        check = 1;
+        error = ghl_error_c2p_singular;
 
-      if(check) {
+      if(error) {
         // We are still failing after exhausting the averaging options.
         // We'll surrender and resort to atmospheric reset...
 
@@ -120,9 +122,11 @@ extern "C" void GRHayLHDX_hybrid_conservs_to_prims(CCTK_ARGUMENTS) {
     //--------------------------------------------------
     //---------- Primitive recovery succeeded ----------
     //--------------------------------------------------
-    // Enforce limits on primitive variables and recompute conservatives.
-    diagnostics.speed_limited += ghl_enforce_primitive_limits_and_compute_u0(
-          ghl_params, ghl_eos, &ADM_metric, &prims);
+    error = ghl_enforce_primitive_limits_and_compute_u0(
+          ghl_params, ghl_eos, &ADM_metric, &prims, &diagnostics.speed_limited);
+    if(error)
+      ghl_read_error_codes(error);
+
     ghl_compute_conservs(
           &ADM_metric, &metric_aux, &prims, &cons);
 

--- a/GRHayLHDX/src/Hybrid/evaluate_fluxes.cxx
+++ b/GRHayLHDX/src/Hybrid/evaluate_fluxes.cxx
@@ -107,8 +107,13 @@ void GRHayLHDX_hybrid_evaluate_fluxes_dir(CCTK_ARGUMENTS) {
     prims_r.BU[0] = prims_r.BU[1] = prims_r.BU[2] = 0.0;
     prims_l.BU[0] = prims_l.BU[1] = prims_l.BU[2] = 0.0;
 
-    int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r);
-    speed_limited = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l);
+    bool speed_limited;
+    ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
+    if(error)
+      ghl_read_error_codes(error);
+    error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
+    if(error)
+      ghl_read_error_codes(error);
 
     CCTK_REAL cmin, cmax;
     ghl_conservative_quantities cons_fluxes;

--- a/GRHayLHDX/src/Hybrid/evaluate_sources_rhs.cxx
+++ b/GRHayLHDX/src/Hybrid/evaluate_sources_rhs.cxx
@@ -40,7 +40,10 @@ void GRHayLHDX_hybrid_evaluate_sources_rhs(CCTK_ARGUMENTS) {
     prims.vU[1] = vy(index);
     prims.vU[2] = vz(index);
 
-    const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims);
+    bool speed_limited;
+    ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
+    if(error)
+      ghl_read_error_codes(error);
 
     const Loop::GF3D2index indm2x(layout, p.I - 2*p.DI[0]);
     const Loop::GF3D2index indm1x(layout, p.I -   p.DI[0]);

--- a/GRHayLHDX/src/Hybrid/prims_to_conservs.cxx
+++ b/GRHayLHDX/src/Hybrid/prims_to_conservs.cxx
@@ -31,9 +31,13 @@ extern "C" void GRHayLHDX_hybrid_prims_to_conservs(CCTK_ARGUMENTS) {
     prims.vU[1] = vy(index);
     prims.vU[2] = vz(index);
 
+    bool speed_limited; 
+    const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
+          ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
+    if(error)
+      ghl_read_error_codes(error);
+
     ghl_conservative_quantities cons;
-    const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_enforce_primitive_limits_and_compute_u0(
-          ghl_params, ghl_eos, &ADM_metric, &prims);
     ghl_compute_conservs(
           &ADM_metric, &metric_aux, &prims, &cons);
 

--- a/GRHayLHDX/src/HybridEntropy/conservs_to_prims.cxx
+++ b/GRHayLHDX/src/HybridEntropy/conservs_to_prims.cxx
@@ -61,7 +61,7 @@ extern "C" void GRHayLHDX_hybrid_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
     cons.SD[2]   = Stildez(index);
     cons.entropy = ent_star(index);
 
-    int check;
+    ghl_error_codes_t error;
 
     cons_orig = cons;
 
@@ -72,21 +72,22 @@ extern "C" void GRHayLHDX_hybrid_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
             &prims, &cons, &diagnostics);
 
       ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
-
-      /************* Conservative-to-primitive recovery ************/
-      check = ghl_con2prim_multi_method(
+      error = ghl_con2prim_multi_method(
             ghl_params, ghl_eos, &ADM_metric, &metric_aux,
             &cons_undens, &prims, &diagnostics);
+
+      if(isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]*
+               prims.entropy)) {
+        error = ghl_error_c2p_singular;
     } else {
+      ghl_set_prims_to_constant_atm(ghl_eos, &prims);
       local_failure_checker += 1;
       //rho_star_fix_applied++;
-      ghl_set_prims_to_constant_atm(ghl_eos, &prims);
-      check = 0;
+      error = ghl_success;
     }
 
     //Add averaging here
-    if(check || isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]*
-                      prims.entropy)) {
+    if(error) {
       // We are still failing after exhausting the averaging options.
       // Next, we try Font1D.
       //pointcount_Font++;
@@ -97,15 +98,15 @@ extern "C" void GRHayLHDX_hybrid_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
 
       ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
 
-      check = ghl_hybrid_Font1D(
+      error = ghl_hybrid_Font1D(
             ghl_params, ghl_eos, &ADM_metric, &metric_aux,
             &cons_undens, &prims, &diagnostics);
 
       if(isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]*
                prims.entropy) )
-        check = 1;
+        error = ghl_error_c2p_singular;
 
-      if(check) {
+      if(error) {
         // We are still failing after exhausting the averaging options.
         // We'll surrender and resort to atmospheric reset...
 
@@ -123,9 +124,11 @@ extern "C" void GRHayLHDX_hybrid_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
     //--------------------------------------------------
     //---------- Primitive recovery succeeded ----------
     //--------------------------------------------------
-    // Enforce limits on primitive variables and recompute conservatives.
-    diagnostics.speed_limited += ghl_enforce_primitive_limits_and_compute_u0(
-          ghl_params, ghl_eos, &ADM_metric, &prims);
+    error = ghl_enforce_primitive_limits_and_compute_u0(
+          ghl_params, ghl_eos, &ADM_metric, &prims, &diagnostics.speed_limited);
+    if(error)
+      ghl_read_error_codes(error);
+
     ghl_compute_conservs(
           &ADM_metric, &metric_aux, &prims, &cons);
 

--- a/GRHayLHDX/src/HybridEntropy/evaluate_fluxes.cxx
+++ b/GRHayLHDX/src/HybridEntropy/evaluate_fluxes.cxx
@@ -113,8 +113,13 @@ void GRHayLHDX_hybrid_entropy_evaluate_fluxes_dir(CCTK_ARGUMENTS) {
     prims_r.BU[0] = prims_r.BU[1] = prims_r.BU[2] = 0.0;
     prims_l.BU[0] = prims_l.BU[1] = prims_l.BU[2] = 0.0;
 
-    int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r);
-    speed_limited = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l);
+    bool speed_limited;
+    ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
+    if(error)
+      ghl_read_error_codes(error);
+    error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
+    if(error)
+      ghl_read_error_codes(error);
 
     CCTK_REAL cmin, cmax;
     ghl_conservative_quantities cons_fluxes;

--- a/GRHayLHDX/src/HybridEntropy/evaluate_sources_rhs.cxx
+++ b/GRHayLHDX/src/HybridEntropy/evaluate_sources_rhs.cxx
@@ -42,7 +42,10 @@ void GRHayLHDX_hybrid_entropy_evaluate_sources_rhs(CCTK_ARGUMENTS) {
     prims.vU[2]   = vz(index);
     prims.entropy = entropy(index);
 
-    const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims);
+    bool speed_limited;
+    ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
+    if(error)
+      ghl_read_error_codes(error);
 
     const Loop::GF3D2index indm2x(layout, p.I - 2*p.DI[0]);
     const Loop::GF3D2index indm1x(layout, p.I -   p.DI[0]);

--- a/GRHayLHDX/src/HybridEntropy/prims_to_conservs.cxx
+++ b/GRHayLHDX/src/HybridEntropy/prims_to_conservs.cxx
@@ -32,9 +32,13 @@ extern "C" void GRHayLHDX_hybrid_entropy_prims_to_conservs(CCTK_ARGUMENTS) {
     prims.vU[2]   = vz(index);
     prims.entropy = entropy(index);
 
+    bool speed_limited; 
+    const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
+          ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
+    if(error)
+      ghl_read_error_codes(error);
+
     ghl_conservative_quantities cons;
-    const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_enforce_primitive_limits_and_compute_u0(
-          ghl_params, ghl_eos, &ADM_metric, &prims);
     ghl_compute_conservs(
           &ADM_metric, &metric_aux, &prims, &cons);
 

--- a/GRHayLHDX/src/Tabulated/evaluate_fluxes.cxx
+++ b/GRHayLHDX/src/Tabulated/evaluate_fluxes.cxx
@@ -105,8 +105,13 @@ void GRHayLHDX_tabulated_evaluate_fluxes_dir(CCTK_ARGUMENTS) {
 
     prims_r.temperature = prims_l.temperature = temperature(index);
 
-    int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r);
-    speed_limited = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l);
+    bool speed_limited;
+    ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
+    if(error)
+      ghl_read_error_codes(error);
+    error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
+    if(error)
+      ghl_read_error_codes(error);
 
     // We must now compute eps and T
     ghl_tabulated_enforce_bounds_rho_Ye_P(ghl_eos, &prims_r.rho, &prims_r.Y_e, &prims_r.press);

--- a/GRHayLHDX/src/Tabulated/evaluate_sources_rhs.cxx
+++ b/GRHayLHDX/src/Tabulated/evaluate_sources_rhs.cxx
@@ -43,7 +43,10 @@ void GRHayLHDX_tabulated_evaluate_sources_rhs(CCTK_ARGUMENTS) {
     prims.Y_e         = Ye(index);
     prims.temperature = temperature(index);
 
-    const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims);
+    bool speed_limited;
+    ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
+    if(error)
+      ghl_read_error_codes(error);
 
     const Loop::GF3D2index indm2x(layout, p.I - 2*p.DI[0]);
     const Loop::GF3D2index indm1x(layout, p.I -   p.DI[0]);

--- a/GRHayLHDX/src/Tabulated/prims_to_conservs.cxx
+++ b/GRHayLHDX/src/Tabulated/prims_to_conservs.cxx
@@ -33,9 +33,13 @@ extern "C" void GRHayLHDX_tabulated_prims_to_conservs(CCTK_ARGUMENTS) {
     prims.Y_e         = Ye(index);
     prims.temperature = temperature(index);
 
+    bool speed_limited; 
+    const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
+          ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
+    if(error)
+      ghl_read_error_codes(error);
+
     ghl_conservative_quantities cons;
-    const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_enforce_primitive_limits_and_compute_u0(
-          ghl_params, ghl_eos, &ADM_metric, &prims);
     ghl_compute_conservs(
           &ADM_metric, &metric_aux, &prims, &cons);
 

--- a/GRHayLHDX/src/TabulatedEntropy/conservs_to_prims.cxx
+++ b/GRHayLHDX/src/TabulatedEntropy/conservs_to_prims.cxx
@@ -62,28 +62,29 @@ extern "C" void GRHayLHDX_tabulated_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
     cons.entropy = ent_star(index);
     cons.Y_e     = Ye_star(index);
 
-    int check;
+    ghl_error_codes_t error;
 
     cons_orig = cons;
 
     /************* Main conservative-to-primitive logic ************/
     if(cons.rho>0.0) {
       ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
-
-      /************* Conservative-to-primitive recovery ************/
-      check = ghl_con2prim_multi_method(
+      error = ghl_con2prim_multi_method(
             ghl_params, ghl_eos, &ADM_metric, &metric_aux,
             &cons_undens, &prims, &diagnostics);
+
+      if(isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]*
+               prims.entropy*prims.Y_e)) {
+        error = ghl_error_c2p_singular;
     } else {
+      ghl_set_prims_to_constant_atm(ghl_eos, &prims);
       local_failure_checker += 1;
       //rho_star_fix_applied++;
-      ghl_set_prims_to_constant_atm(ghl_eos, &prims);
-      check = 0;
+      error = ghl_success;
     }
 
     //Add averaging here
-    if(check || isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]*
-                      prims.entropy*prims.Y_e)) {
+    if(error) {
 
       // We are still failing after exhausting the averaging options.
       // We'll surrender and resort to atmospheric reset...
@@ -101,9 +102,11 @@ extern "C" void GRHayLHDX_tabulated_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
     //--------------------------------------------------
     //---------- Primitive recovery succeeded ----------
     //--------------------------------------------------
-    // Enforce limits on primitive variables and recompute conservatives.
-    diagnostics.speed_limited += ghl_enforce_primitive_limits_and_compute_u0(
-          ghl_params, ghl_eos, &ADM_metric, &prims);
+    error = ghl_enforce_primitive_limits_and_compute_u0(
+          ghl_params, ghl_eos, &ADM_metric, &prims, &diagnostics.speed_limited);
+    if(error)
+      ghl_read_error_codes(error);
+
     ghl_compute_conservs(
           &ADM_metric, &metric_aux, &prims, &cons);
 

--- a/GRHayLHDX/src/TabulatedEntropy/evaluate_fluxes.cxx
+++ b/GRHayLHDX/src/TabulatedEntropy/evaluate_fluxes.cxx
@@ -110,8 +110,13 @@ void GRHayLHDX_tabulated_entropy_evaluate_fluxes_dir(CCTK_ARGUMENTS) {
 
     prims_r.temperature = prims_l.temperature = temperature(index);
 
-    int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r);
-    speed_limited = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l);
+    bool speed_limited;
+    ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
+    if(error)
+      ghl_read_error_codes(error);
+    error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
+    if(error)
+      ghl_read_error_codes(error);
 
     // We must now compute eps and T
     ghl_tabulated_enforce_bounds_rho_Ye_P(ghl_eos, &prims_r.rho, &prims_r.Y_e, &prims_r.press);

--- a/GRHayLHDX/src/TabulatedEntropy/evaluate_sources_rhs.cxx
+++ b/GRHayLHDX/src/TabulatedEntropy/evaluate_sources_rhs.cxx
@@ -45,7 +45,10 @@ void GRHayLHDX_tabulated_entropy_evaluate_sources_rhs(CCTK_ARGUMENTS) {
     prims.Y_e         = Ye(index);
     prims.temperature = temperature(index);
 
-    const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims);
+    bool speed_limited;
+    ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
+    if(error)
+      ghl_read_error_codes(error);
 
     const Loop::GF3D2index indm2x(layout, p.I - 2*p.DI[0]);
     const Loop::GF3D2index indm1x(layout, p.I -   p.DI[0]);

--- a/GRHayLHDX/src/TabulatedEntropy/prims_to_conservs.cxx
+++ b/GRHayLHDX/src/TabulatedEntropy/prims_to_conservs.cxx
@@ -34,9 +34,13 @@ extern "C" void GRHayLHDX_tabulated_entropy_prims_to_conservs(CCTK_ARGUMENTS) {
     prims.Y_e         = Ye(index);
     prims.temperature = temperature(index);
 
+    bool speed_limited; 
+    const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
+          ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
+    if(error)
+      ghl_read_error_codes(error);
+
     ghl_conservative_quantities cons;
-    const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_enforce_primitive_limits_and_compute_u0(
-          ghl_params, ghl_eos, &ADM_metric, &prims);
     ghl_compute_conservs(
           &ADM_metric, &metric_aux, &prims, &cons);
 

--- a/IllinoisGRMHD/src/Hybrid/calculate_fluxes_rhs.c
+++ b/IllinoisGRMHD/src/Hybrid/calculate_fluxes_rhs.c
@@ -180,8 +180,13 @@ void IllinoisGRMHD_hybrid_calculate_flux_dir_rhs(
         prims_l.vU[1] = vel_l[1][index];
         prims_l.vU[2] = vel_l[2][index];
 
-        int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r);
-        speed_limited = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l);
+        bool speed_limited;
+        ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
+        error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
 
         ghl_conservative_quantities cons_fluxes;
         calculate_characteristic_speed(&prims_r, &prims_l, ghl_eos, &ADM_metric_face, &cmin[index], &cmax[index]);

--- a/IllinoisGRMHD/src/Hybrid/conservs_to_prims.c
+++ b/IllinoisGRMHD/src/Hybrid/conservs_to_prims.c
@@ -80,7 +80,7 @@ void IllinoisGRMHD_hybrid_conservs_to_prims(CCTK_ARGUMENTS) {
         cons.SD[1] = Stildey[index];
         cons.SD[2] = Stildez[index];
 
-        int check;
+        ghl_error_codes_t error;
 
         /************* Main conservative-to-primitive logic ************/
         if(cons.rho>0.0) {
@@ -89,21 +89,21 @@ void IllinoisGRMHD_hybrid_conservs_to_prims(CCTK_ARGUMENTS) {
               &prims, &cons, &diagnostics);
 
           ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
-
-          /************* Conservative-to-primitive recovery ************/
-          check = ghl_con2prim_multi_method(
+          error = ghl_con2prim_multi_method(
                 ghl_params, ghl_eos, &ADM_metric, &metric_aux,
                 &cons_undens, &prims, &diagnostics);
+
+          if(isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]))
+            error = ghl_error_c2p_singular;
         } else {
           ghl_set_prims_to_constant_atm(ghl_eos, &prims);
           local_failure_checker += 1;
           rho_star_fix_applied++;
-          check = 0;
+          error = ghl_success;
         }
 
-        if(check || isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2])) {
+        if(error) {
           pointcount_avg++;
-          check = 1;
 
           // Reload cons for consistency (hybrid applies limits to cons)
           cons.rho   = rho_star[index];
@@ -147,8 +147,7 @@ void IllinoisGRMHD_hybrid_conservs_to_prims(CCTK_ARGUMENTS) {
           }
 
           int avg_weight = 1;
-          while(check && avg_weight < 5) {
-            check = 0;
+          while(error && avg_weight < 5) {
             // last point doesn't add central point and has 1 less point
             // being averaged.
             n_avg += (avg_weight!=4);
@@ -170,15 +169,15 @@ void IllinoisGRMHD_hybrid_conservs_to_prims(CCTK_ARGUMENTS) {
             ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons_avg, &cons_undens);
 
             /************* Conservative-to-primitive recovery ************/
-            check = ghl_con2prim_multi_method(
+            error = ghl_con2prim_multi_method(
                   ghl_params, ghl_eos, &ADM_metric, &metric_aux,
                   &cons_undens, &prims, &diagnostics);
 
             avg_weight++;
             if(isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]) )
-              check = 1;
+              error = ghl_error_c2p_singular;
           }
-          if(check) {
+          if(error) {
             // We are still failing after exhausting the averaging options.
             // Next, we try Font1D.
             pointcount_Font++;
@@ -189,19 +188,18 @@ void IllinoisGRMHD_hybrid_conservs_to_prims(CCTK_ARGUMENTS) {
 
             ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
 
-            check = ghl_hybrid_Font1D(
+            error = ghl_hybrid_Font1D(
                   ghl_params, ghl_eos, &ADM_metric, &metric_aux,
                   &cons_undens, &prims, &diagnostics);
 
             if(isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]) )
-              check = 1;
+              error = ghl_error_c2p_singular;
 
-            if(check) {
+            if(error) {
               // We are still failing after exhausting the averaging options.
               // We'll surrender and resort to atmospheric reset...
 
               failure_checker[index] += 100;
-
               ghl_set_prims_to_constant_atm(ghl_eos, &prims);
 
               failures++;
@@ -209,20 +207,6 @@ void IllinoisGRMHD_hybrid_conservs_to_prims(CCTK_ARGUMENTS) {
                 failures_inhoriz++;
                 pointcount_inhoriz++;
               }
-              CCTK_VINFO("***********************************************************\n"
-                         "Con2Prim and averaging backups failed! Resetting to atmosphere...\n"
-                         "position = %e %e %e\n"
-                         "lapse, shift = %e, %e, %e, %e\n"
-                         "gij = %e, %e, %e, %e, %e, %e\n"
-                         "B^i = %e, %e, %e\n"
-                         "rho_*, ~tau, ~S_{i}: %e, %e, %e, %e, %e\n"
-                       "***********************************************************",
-                         x[index], y[index], z[index],
-                         ADM_metric.lapse, ADM_metric.betaU[0], ADM_metric.betaU[1], ADM_metric.betaU[2],
-                         ADM_metric.gammaDD[0][0], ADM_metric.gammaDD[0][1], ADM_metric.gammaDD[0][2],
-                         ADM_metric.gammaDD[1][1], ADM_metric.gammaDD[1][2], ADM_metric.gammaDD[2][2],
-                         prims.BU[0], prims.BU[1], prims.BU[2],
-                         cons.rho, cons.tau, cons.SD[0], cons.SD[1], cons.SD[2]);
             } // atmospheric backup
           } // Font1D backup
         } // if c2p failed
@@ -232,8 +216,10 @@ void IllinoisGRMHD_hybrid_conservs_to_prims(CCTK_ARGUMENTS) {
         //---------- Primitive recovery succeeded ----------
         //--------------------------------------------------
         // Enforce limits on primitive variables and recompute conservatives.
-        diagnostics.speed_limited += ghl_enforce_primitive_limits_and_compute_u0(
-              ghl_params, ghl_eos, &ADM_metric, &prims);
+        error = ghl_enforce_primitive_limits_and_compute_u0(
+              ghl_params, ghl_eos, &ADM_metric, &prims, &diagnostics.speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
 
         rho[index]   = prims.rho;
         press[index] = prims.press;

--- a/IllinoisGRMHD/src/Hybrid/evaluate_sources_rhs.c
+++ b/IllinoisGRMHD/src/Hybrid/evaluate_sources_rhs.c
@@ -51,8 +51,10 @@ void IllinoisGRMHD_hybrid_evaluate_sources_rhs(CCTK_ARGUMENTS) {
         prims.BU[1] = By_center[index];
         prims.BU[2] = Bz_center[index];
 
-        const int speed_limited CCTK_ATTRIBUTE_UNUSED =
-              ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims);
+        bool speed_limited;
+        ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
 
         ghl_metric_quantities ADM_metric_derivs_x;
         IllinoisGRMHD_compute_metric_derivs(

--- a/IllinoisGRMHD/src/Hybrid/hydro_outer_boundaries.c
+++ b/IllinoisGRMHD/src/Hybrid/hydro_outer_boundaries.c
@@ -200,10 +200,13 @@ void IllinoisGRMHD_hybrid_enforce_primitive_limits_and_compute_conservs(const cG
   ghl_ADM_aux_quantities metric_aux;
   ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
 
-  ghl_conservative_quantities cons;
-  const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_enforce_primitive_limits_and_compute_u0(
-        ghl_params, ghl_eos, &ADM_metric, prims);
+  bool speed_limited;
+  ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
+        ghl_params, ghl_eos, &ADM_metric, prims, &speed_limited);
+  if(error)
+    ghl_read_error_codes(error);
 
+  ghl_conservative_quantities cons;
   ghl_compute_conservs(
         &ADM_metric, &metric_aux, prims, &cons);
 

--- a/IllinoisGRMHD/src/Hybrid/prims_to_conservs.c
+++ b/IllinoisGRMHD/src/Hybrid/prims_to_conservs.c
@@ -35,9 +35,13 @@ void IllinoisGRMHD_hybrid_prims_to_conservs(CCTK_ARGUMENTS) {
         prims.BU[1] = By_center[index];
         prims.BU[2] = Bz_center[index];
 
+        bool speed_limited; 
+        const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
+              ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
+
         ghl_conservative_quantities cons;
-        const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_enforce_primitive_limits_and_compute_u0(
-              ghl_params, ghl_eos, &ADM_metric, &prims);
         ghl_compute_conservs(
               &ADM_metric, &metric_aux, &prims, &cons);
 

--- a/IllinoisGRMHD/src/HybridEntropy/calculate_fluxes_rhs.c
+++ b/IllinoisGRMHD/src/HybridEntropy/calculate_fluxes_rhs.c
@@ -182,8 +182,13 @@ void IllinoisGRMHD_hybrid_entropy_calculate_flux_dir_rhs(
         prims_l.vU[1] = vel_l[1][index];
         prims_l.vU[2] = vel_l[2][index];
 
-        int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r);
-        speed_limited = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l);
+        bool speed_limited;
+        ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
+        error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
 
         ghl_conservative_quantities cons_fluxes;
         calculate_characteristic_speed(&prims_r, &prims_l, ghl_eos, &ADM_metric_face, &cmin[index], &cmax[index]);

--- a/IllinoisGRMHD/src/HybridEntropy/conservs_to_prims.c
+++ b/IllinoisGRMHD/src/HybridEntropy/conservs_to_prims.c
@@ -82,7 +82,7 @@ void IllinoisGRMHD_hybrid_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
         cons.SD[2]   = Stildez[index];
         cons.entropy = ent_star[index];
 
-        int check;
+        ghl_error_codes_t error;
 
         /************* Main conservative-to-primitive logic ************/
         if(cons.rho>0.0) {
@@ -91,22 +91,21 @@ void IllinoisGRMHD_hybrid_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
               &prims, &cons, &diagnostics);
 
           ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
-
-          /************* Conservative-to-primitive recovery ************/
-          check = ghl_con2prim_multi_method(
+          error = ghl_con2prim_multi_method(
                 ghl_params, ghl_eos, &ADM_metric, &metric_aux,
                 &cons_undens, &prims, &diagnostics);
+
+          if(isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]*
+                            prims.entropy)) {
+            error = ghl_error_c2p_singular;
         } else {
           ghl_set_prims_to_constant_atm(ghl_eos, &prims);
           local_failure_checker += 1;
           rho_star_fix_applied++;
-          check = 0;
+          error = ghl_success;
         }
 
-        if(check || isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]*
-                          prims.entropy)) {
           pointcount_avg++;
-          check = 1;
 
           // Reload cons for consistency (hybrid applies limits to cons)
           cons.rho     = rho_star[index];
@@ -153,8 +152,7 @@ void IllinoisGRMHD_hybrid_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
           }
 
           int avg_weight = 1;
-          while(check && avg_weight < 5) {
-            check = 0;
+          while(error && avg_weight < 5) {
             // last point doesn't add central point and has 1 less point
             // being averaged.
             n_avg += (avg_weight!=4);
@@ -178,16 +176,16 @@ void IllinoisGRMHD_hybrid_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
             ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons_avg, &cons_undens);
 
             /************* Conservative-to-primitive recovery ************/
-            check = ghl_con2prim_multi_method(
+            error = ghl_con2prim_multi_method(
                   ghl_params, ghl_eos, &ADM_metric, &metric_aux,
                   &cons_undens, &prims, &diagnostics);
 
             avg_weight++;
             if(isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]*
                      prims.entropy) )
-              check = 1;
+              error = ghl_error_c2p_singular;
           }
-          if(check) {
+          if(error) {
             // We are still failing after exhausting the averaging options.
             // Next, we try Font1D.
             pointcount_Font++;
@@ -198,15 +196,15 @@ void IllinoisGRMHD_hybrid_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
 
             ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
 
-            check = ghl_hybrid_Font1D(
+            error = ghl_hybrid_Font1D(
                   ghl_params, ghl_eos, &ADM_metric, &metric_aux,
                   &cons_undens, &prims, &diagnostics);
 
             if(isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]*
                      prims.entropy) )
-              check = 1;
+              error = ghl_error_c2p_singular;
 
-            if(check) {
+            if(error) {
               // We are still failing after exhausting the averaging options.
               // We'll surrender and resort to atmospheric reset...
 
@@ -219,22 +217,6 @@ void IllinoisGRMHD_hybrid_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
                 failures_inhoriz++;
                 pointcount_inhoriz++;
               }
-              CCTK_VINFO("***********************************************************\n"
-                         "Con2Prim and averaging backups failed! Resetting to atmosphere...\n"
-                         "position = %e %e %e\n"
-                         "lapse, shift = %e, %e, %e, %e\n"
-                         "gij = %e, %e, %e, %e, %e, %e\n"
-                         "B^i = %e, %e, %e\n"
-                         "rho_*, ~tau, ~S_{i}: %e, %e, %e, %e, %e\n"
-                         "~DS: %e\n"
-                       "***********************************************************",
-                         x[index], y[index], z[index],
-                         ADM_metric.lapse, ADM_metric.betaU[0], ADM_metric.betaU[1], ADM_metric.betaU[2],
-                         ADM_metric.gammaDD[0][0], ADM_metric.gammaDD[0][1], ADM_metric.gammaDD[0][2],
-                         ADM_metric.gammaDD[1][1], ADM_metric.gammaDD[1][2], ADM_metric.gammaDD[2][2],
-                         prims.BU[0], prims.BU[1], prims.BU[2],
-                         cons.rho, cons.tau, cons.SD[0], cons.SD[1], cons.SD[2],
-                         cons.entropy);
             } // atmospheric backup
           } // Font1D backup
         } // if c2p failed
@@ -244,8 +226,10 @@ void IllinoisGRMHD_hybrid_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
         //---------- Primitive recovery succeeded ----------
         //--------------------------------------------------
         // Enforce limits on primitive variables and recompute conservatives.
-        diagnostics.speed_limited += ghl_enforce_primitive_limits_and_compute_u0(
-              ghl_params, ghl_eos, &ADM_metric, &prims);
+        error = ghl_enforce_primitive_limits_and_compute_u0(
+              ghl_params, ghl_eos, &ADM_metric, &prims, &diagnostics.speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
 
         rho[index]     = prims.rho;
         press[index]   = prims.press;

--- a/IllinoisGRMHD/src/HybridEntropy/evaluate_sources_rhs.c
+++ b/IllinoisGRMHD/src/HybridEntropy/evaluate_sources_rhs.c
@@ -53,8 +53,10 @@ void IllinoisGRMHD_hybrid_entropy_evaluate_sources_rhs(CCTK_ARGUMENTS) {
         prims.BU[2] = Bz_center[index];
         prims.entropy = entropy[index];
 
-        const int speed_limited CCTK_ATTRIBUTE_UNUSED =
-              ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims);
+        bool speed_limited;
+        ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
 
         ghl_metric_quantities ADM_metric_derivs_x;
         IllinoisGRMHD_compute_metric_derivs(

--- a/IllinoisGRMHD/src/HybridEntropy/hydro_outer_boundaries.c
+++ b/IllinoisGRMHD/src/HybridEntropy/hydro_outer_boundaries.c
@@ -206,10 +206,13 @@ void IllinoisGRMHD_hybrid_entropy_enforce_primitive_limits_and_compute_conservs(
   ghl_ADM_aux_quantities metric_aux;
   ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
 
-  ghl_conservative_quantities cons;
-  const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_enforce_primitive_limits_and_compute_u0(
-        ghl_params, ghl_eos, &ADM_metric, prims);
+  bool speed_limited;
+  ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
+        ghl_params, ghl_eos, &ADM_metric, prims, &speed_limited);
+  if(error)
+    ghl_read_error_codes(error);
 
+  ghl_conservative_quantities cons;
   ghl_compute_conservs(
         &ADM_metric, &metric_aux, prims, &cons);
 

--- a/IllinoisGRMHD/src/HybridEntropy/prims_to_conservs.c
+++ b/IllinoisGRMHD/src/HybridEntropy/prims_to_conservs.c
@@ -36,9 +36,13 @@ void IllinoisGRMHD_hybrid_entropy_prims_to_conservs(CCTK_ARGUMENTS) {
         prims.BU[2]   = Bz_center[index];
         prims.entropy = entropy[index];
 
+        bool speed_limited; 
+        const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
+              ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
+
         ghl_conservative_quantities cons;
-        const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_enforce_primitive_limits_and_compute_u0(
-              ghl_params, ghl_eos, &ADM_metric, &prims);
         ghl_compute_conservs(
               &ADM_metric, &metric_aux, &prims, &cons);
 

--- a/IllinoisGRMHD/src/Tabulated/calculate_fluxes_rhs.c
+++ b/IllinoisGRMHD/src/Tabulated/calculate_fluxes_rhs.c
@@ -175,8 +175,13 @@ void IllinoisGRMHD_tabulated_calculate_flux_dir_rhs(
 
         prims_r.temperature = prims_l.temperature = temperature[index];
 
-        int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r);
-        speed_limited = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l);
+        bool speed_limited;
+        ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
+        error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
 
         // We must now compute eps and T
         ghl_tabulated_enforce_bounds_rho_Ye_P(ghl_eos, &prims_r.rho, &prims_r.Y_e, &prims_r.press);

--- a/IllinoisGRMHD/src/Tabulated/conservs_to_prims.c
+++ b/IllinoisGRMHD/src/Tabulated/conservs_to_prims.c
@@ -81,27 +81,26 @@ void IllinoisGRMHD_tabulated_conservs_to_prims(CCTK_ARGUMENTS) {
         cons.SD[2] = Stildez[index];
         cons.Y_e   = Ye_star[index];
 
-        int check;
+        ghl_error_codes_t error;
 
         /************* Main conservative-to-primitive logic ************/
         if(cons.rho>0.0) {
           ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
-
-          /************* Conservative-to-primitive recovery ************/
-          check = ghl_con2prim_multi_method(
+          error = ghl_con2prim_multi_method(
                 ghl_params, ghl_eos, &ADM_metric, &metric_aux,
                 &cons_undens, &prims, &diagnostics);
+
+          if(isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]*
+                            prims.Y_e*prims.temperature)) {
+            error = ghl_error_c2p_singular;
         } else {
           ghl_set_prims_to_constant_atm(ghl_eos, &prims);
           local_failure_checker += 1;
           rho_star_fix_applied++;
-          check = 0;
+          error = ghl_success;
         }
 
-        if(check || isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]*
-                          prims.Y_e*prims.temperature)) {
           pointcount_avg++;
-          check = 1;
 
           ghl_conservative_quantities cons_neigh_avg, cons_avg;
           cons_neigh_avg.rho   = 0.0;
@@ -140,8 +139,7 @@ void IllinoisGRMHD_tabulated_conservs_to_prims(CCTK_ARGUMENTS) {
           }
 
           int avg_weight = 1;
-          while(check && avg_weight < 5) {
-            check = 0;
+          while(error && avg_weight < 5) {
             // last point doesn't add central point and has 1 less point
             // being averaged.
             n_avg += (avg_weight!=4);
@@ -165,16 +163,16 @@ void IllinoisGRMHD_tabulated_conservs_to_prims(CCTK_ARGUMENTS) {
             ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons_avg, &cons_undens);
 
             /************* Conservative-to-primitive recovery ************/
-            check = ghl_con2prim_multi_method(
+            error = ghl_con2prim_multi_method(
                   ghl_params, ghl_eos, &ADM_metric, &metric_aux,
                   &cons_undens, &prims, &diagnostics);
 
             avg_weight++;
             if(isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]*
                      prims.Y_e*prims.temperature) )
-              check = 1;
+              error = ghl_error_c2p_singular;
           }
-          if(check) {
+          if(error) {
             // We are still failing after exhausting the averaging options.
             // We'll surrender and resort to atmospheric reset...
 
@@ -187,22 +185,6 @@ void IllinoisGRMHD_tabulated_conservs_to_prims(CCTK_ARGUMENTS) {
               failures_inhoriz++;
               pointcount_inhoriz++;
             }
-            CCTK_VINFO("***********************************************************\n"
-                       "Con2Prim and averaging backups failed! Resetting to atmosphere...\n"
-                       "position = %e %e %e\n"
-                       "lapse, shift = %e, %e, %e, %e\n"
-                       "gij = %e, %e, %e, %e, %e, %e\n"
-                       "B^i = %e, %e, %e\n"
-                       "rho_*, ~tau, ~S_{i}: %e, %e, %e, %e, %e\n"
-                       "~DYe: %e\n"
-                       "***********************************************************",
-                       x[index], y[index], z[index],
-                       ADM_metric.lapse, ADM_metric.betaU[0], ADM_metric.betaU[1], ADM_metric.betaU[2],
-                       ADM_metric.gammaDD[0][0], ADM_metric.gammaDD[0][1], ADM_metric.gammaDD[0][2],
-                       ADM_metric.gammaDD[1][1], ADM_metric.gammaDD[1][2], ADM_metric.gammaDD[2][2],
-                       prims.BU[0], prims.BU[1], prims.BU[2],
-                       cons.rho, cons.tau, cons.SD[0], cons.SD[1], cons.SD[2],
-                       cons.Y_e);
           } // atmospheric backup
         } // if c2p failed
         /***************************************************************/
@@ -211,8 +193,10 @@ void IllinoisGRMHD_tabulated_conservs_to_prims(CCTK_ARGUMENTS) {
         //---------- Primitive recovery succeeded ----------
         //--------------------------------------------------
         // Enforce limits on primitive variables and recompute conservatives.
-        diagnostics.speed_limited += ghl_enforce_primitive_limits_and_compute_u0(
-              ghl_params, ghl_eos, &ADM_metric, &prims);
+        error = ghl_enforce_primitive_limits_and_compute_u0(
+              ghl_params, ghl_eos, &ADM_metric, &prims, &diagnostics.speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
 
         rho[index]         = prims.rho;
         press[index]       = prims.press;

--- a/IllinoisGRMHD/src/Tabulated/evaluate_sources_rhs.c
+++ b/IllinoisGRMHD/src/Tabulated/evaluate_sources_rhs.c
@@ -54,8 +54,10 @@ void IllinoisGRMHD_tabulated_evaluate_sources_rhs(CCTK_ARGUMENTS) {
         prims.Y_e         = Y_e[index];
         prims.temperature = temperature[index];
 
-        const int speed_limited CCTK_ATTRIBUTE_UNUSED =
-              ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims);
+        bool speed_limited;
+        ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
 
         ghl_metric_quantities ADM_metric_derivs_x;
         IllinoisGRMHD_compute_metric_derivs(

--- a/IllinoisGRMHD/src/Tabulated/hydro_outer_boundaries.c
+++ b/IllinoisGRMHD/src/Tabulated/hydro_outer_boundaries.c
@@ -212,10 +212,13 @@ void IllinoisGRMHD_tabulated_enforce_primitive_limits_and_compute_conservs(const
   ghl_ADM_aux_quantities metric_aux;
   ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
 
-  ghl_conservative_quantities cons;
-  const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_enforce_primitive_limits_and_compute_u0(
-        ghl_params, ghl_eos, &ADM_metric, prims);
+  bool speed_limited;
+  ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
+        ghl_params, ghl_eos, &ADM_metric, prims, &speed_limited);
+  if(error)
+    ghl_read_error_codes(error);
 
+  ghl_conservative_quantities cons;
   ghl_compute_conservs(
         &ADM_metric, &metric_aux, prims, &cons);
 

--- a/IllinoisGRMHD/src/Tabulated/prims_to_conservs.c
+++ b/IllinoisGRMHD/src/Tabulated/prims_to_conservs.c
@@ -37,9 +37,13 @@ void IllinoisGRMHD_tabulated_prims_to_conservs(CCTK_ARGUMENTS) {
         prims.Y_e         = Y_e[index];
         prims.temperature = temperature[index];
 
+        bool speed_limited; 
+        const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
+              ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
+
         ghl_conservative_quantities cons;
-        const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_enforce_primitive_limits_and_compute_u0(
-              ghl_params, ghl_eos, &ADM_metric, &prims);
         ghl_compute_conservs(
               &ADM_metric, &metric_aux, &prims, &cons);
 

--- a/IllinoisGRMHD/src/TabulatedEntropy/calculate_fluxes_rhs.c
+++ b/IllinoisGRMHD/src/TabulatedEntropy/calculate_fluxes_rhs.c
@@ -177,8 +177,13 @@ void IllinoisGRMHD_tabulated_entropy_calculate_flux_dir_rhs(
 
         prims_r.temperature = prims_l.temperature = temperature[index];
 
-        int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r);
-        speed_limited = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l);
+        bool speed_limited;
+        ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
+        error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
 
         // We must now compute eps and T
         ghl_tabulated_enforce_bounds_rho_Ye_P(ghl_eos, &prims_r.rho, &prims_r.Y_e, &prims_r.press);

--- a/IllinoisGRMHD/src/TabulatedEntropy/conservs_to_prims.c
+++ b/IllinoisGRMHD/src/TabulatedEntropy/conservs_to_prims.c
@@ -83,27 +83,26 @@ void IllinoisGRMHD_tabulated_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
         cons.entropy = ent_star[index];
         cons.Y_e     = Ye_star[index];
 
-        int check;
+        ghl_error_codes_t error;
 
         /************* Main conservative-to-primitive logic ************/
         if(cons.rho>0.0) {
           ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
-
-          /************* Conservative-to-primitive recovery ************/
-          check = ghl_con2prim_multi_method(
+          error = ghl_con2prim_multi_method(
                 ghl_params, ghl_eos, &ADM_metric, &metric_aux,
                 &cons_undens, &prims, &diagnostics);
+
+          if(isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]*
+                            prims.entropy*prims.Y_e*prims.temperature)) {
+            error = ghl_error_c2p_singular;
         } else {
           ghl_set_prims_to_constant_atm(ghl_eos, &prims);
           local_failure_checker += 1;
           rho_star_fix_applied++;
-          check = 0;
+          error = ghl_success;
         }
 
-        if(check || isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]*
-                          prims.entropy*prims.Y_e*prims.temperature)) {
           pointcount_avg++;
-          check = 1;
 
           ghl_conservative_quantities cons_neigh_avg, cons_avg;
           cons_neigh_avg.rho     = 0.0;
@@ -144,8 +143,7 @@ void IllinoisGRMHD_tabulated_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
           }
 
           int avg_weight = 1;
-          while(check && avg_weight < 5) {
-            check = 0;
+          while(error && avg_weight < 5) {
             // last point doesn't add central point and has 1 less point
             // being averaged.
             n_avg += (avg_weight!=4);
@@ -171,16 +169,16 @@ void IllinoisGRMHD_tabulated_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
             ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons_avg, &cons_undens);
 
             /************* Conservative-to-primitive recovery ************/
-            check = ghl_con2prim_multi_method(
+            error = ghl_con2prim_multi_method(
                   ghl_params, ghl_eos, &ADM_metric, &metric_aux,
                   &cons_undens, &prims, &diagnostics);
 
             avg_weight++;
             if(isnan(prims.rho*prims.press*prims.eps*prims.vU[0]*prims.vU[1]*prims.vU[2]*
                      prims.entropy*prims.Y_e*prims.temperature) )
-              check = 1;
+              error = ghl_error_c2p_singular;
           }
-          if(check) {
+          if(error) {
             // We are still failing after exhausting the averaging options.
             // We'll surrender and resort to atmospheric reset...
 
@@ -193,22 +191,6 @@ void IllinoisGRMHD_tabulated_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
               failures_inhoriz++;
               pointcount_inhoriz++;
             }
-            CCTK_VINFO("***********************************************************\n"
-                       "Con2Prim and averaging backups failed! Resetting to atmosphere...\n"
-                       "position = %e %e %e\n"
-                       "lapse, shift = %e, %e, %e, %e\n"
-                       "gij = %e, %e, %e, %e, %e, %e\n"
-                       "B^i = %e, %e, %e\n"
-                       "rho_*, ~tau, ~S_{i}: %e, %e, %e, %e, %e\n"
-                       "~DS, ~DYe: %e, %e\n"
-                       "***********************************************************",
-                       x[index], y[index], z[index],
-                       ADM_metric.lapse, ADM_metric.betaU[0], ADM_metric.betaU[1], ADM_metric.betaU[2],
-                       ADM_metric.gammaDD[0][0], ADM_metric.gammaDD[0][1], ADM_metric.gammaDD[0][2],
-                       ADM_metric.gammaDD[1][1], ADM_metric.gammaDD[1][2], ADM_metric.gammaDD[2][2],
-                       prims.BU[0], prims.BU[1], prims.BU[2],
-                       cons.rho, cons.tau, cons.SD[0], cons.SD[1], cons.SD[2],
-                       cons.entropy, cons.Y_e);
           } // atmospheric backup
         } // if c2p failed
         /***************************************************************/
@@ -217,8 +199,10 @@ void IllinoisGRMHD_tabulated_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
         //---------- Primitive recovery succeeded ----------
         //--------------------------------------------------
         // Enforce limits on primitive variables and recompute conservatives.
-        diagnostics.speed_limited += ghl_enforce_primitive_limits_and_compute_u0(
-              ghl_params, ghl_eos, &ADM_metric, &prims);
+        error = ghl_enforce_primitive_limits_and_compute_u0(
+              ghl_params, ghl_eos, &ADM_metric, &prims, &diagnostics.speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
 
         rho[index]         = prims.rho;
         press[index]       = prims.press;

--- a/IllinoisGRMHD/src/TabulatedEntropy/evaluate_sources_rhs.c
+++ b/IllinoisGRMHD/src/TabulatedEntropy/evaluate_sources_rhs.c
@@ -56,8 +56,10 @@ void IllinoisGRMHD_tabulated_entropy_evaluate_sources_rhs(CCTK_ARGUMENTS) {
         prims.Y_e         = Y_e[index];
         prims.temperature = temperature[index];
 
-        const int speed_limited CCTK_ATTRIBUTE_UNUSED =
-              ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims);
+        bool speed_limited;
+        ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
 
         ghl_metric_quantities ADM_metric_derivs_x;
         IllinoisGRMHD_compute_metric_derivs(

--- a/IllinoisGRMHD/src/TabulatedEntropy/hydro_outer_boundaries.c
+++ b/IllinoisGRMHD/src/TabulatedEntropy/hydro_outer_boundaries.c
@@ -218,10 +218,13 @@ void IllinoisGRMHD_tabulated_entropy_enforce_primitive_limits_and_compute_conser
   ghl_ADM_aux_quantities metric_aux;
   ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
 
-  ghl_conservative_quantities cons;
-  const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_enforce_primitive_limits_and_compute_u0(
-        ghl_params, ghl_eos, &ADM_metric, prims);
+  bool speed_limited;
+  ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
+        ghl_params, ghl_eos, &ADM_metric, prims, &speed_limited);
+  if(error)
+    ghl_read_error_codes(error);
 
+  ghl_conservative_quantities cons;
   ghl_compute_conservs(
         &ADM_metric, &metric_aux, prims, &cons);
 

--- a/IllinoisGRMHD/src/TabulatedEntropy/prims_to_conservs.c
+++ b/IllinoisGRMHD/src/TabulatedEntropy/prims_to_conservs.c
@@ -38,9 +38,13 @@ void IllinoisGRMHD_tabulated_entropy_prims_to_conservs(CCTK_ARGUMENTS) {
         prims.Y_e         = Y_e[index];
         prims.temperature = temperature[index];
 
+        bool speed_limited; 
+        const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
+              ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
+        if(error)
+          ghl_read_error_codes(error);
+
         ghl_conservative_quantities cons;
-        const int speed_limited CCTK_ATTRIBUTE_UNUSED = ghl_enforce_primitive_limits_and_compute_u0(
-              ghl_params, ghl_eos, &ADM_metric, &prims);
         ghl_compute_conservs(
               &ADM_metric, &metric_aux, &prims, &cons);
 


### PR DESCRIPTION
GRHayL (via GRHayLib thorn) had several changes to improve the portability of its functions--especially for eventual gpu support. This primarily involved standardizing/condensing error codes and replacing warning/error messages with return codes.