### PR TITLE
Fix schedule issue with latest CarpetX

### DIFF
--- a/GRHayLHDX/interface.ccl
+++ b/GRHayLHDX/interface.ccl
@@ -12,7 +12,7 @@ USES INCLUDE: GRHayLib.h
 # The metric quantities in ADMBase are defined at vertices,
 # but we need them at cell centers. Since this computation will
 # need to be done repeatedly, it is better to store these values.
-CCTK_REAL ccc_spacetime type = GF CENTERING={ccc} TAGS='InterpNumTimelevels=1 prolongation="none" parity={ +1 +1 +1  +1 +1 +1  -1 +1 +1  +1 -1 +1  +1 +1 -1}' #should depend on ADMBase::metric, ADMBase::shift, ADMBase::lapse
+CCTK_REAL ccc_spacetime type = GF CENTERING={ccc} TAGS='InterpNumTimelevels=1 prolongation="none" checkpoint="no" parity={ +1 +1 +1  +1 +1 +1  -1 +1 +1  +1 -1 +1  +1 +1 -1}' #should depend on ADMBase::metric, ADMBase::shift, ADMBase::lapse
 {
   ccc_lapse,
   ccc_betax, ccc_betay, ccc_betaz
@@ -20,13 +20,13 @@ CCTK_REAL ccc_spacetime type = GF CENTERING={ccc} TAGS='InterpNumTimelevels=1 pr
   ccc_gyy, ccc_gyz, ccc_gzz
 } "Cell-centered spacetime quantities"
 
-CCTK_REAL ccc_curv type = GF CENTERING={ccc} TAGS='InterpNumTimelevels=1 prolongation="none" parity={ +1 +1 +1  +1 +1 +1  -1 +1 +1  +1 -1 +1  +1 +1 -1}' #should depend on ADMBase::curv
+CCTK_REAL ccc_curv type = GF CENTERING={ccc} TAGS='InterpNumTimelevels=1 prolongation="none" checkpoint="no" parity={ +1 +1 +1  +1 +1 +1  -1 +1 +1  +1 -1 +1  +1 +1 -1}' #should depend on ADMBase::curv
 {
   ccc_kxx, ccc_kxy, ccc_kxz
   ccc_kyy, ccc_kyz, ccc_kzz
 } "Cell-centered extrinsic curvature"
 
-CCTK_REAL ccc_Tmunu type = GF CENTERING={ccc} TAGS='InterpNumTimelevels=1 prolongation="none" parity={ +1 +1 +1  +1 +1 +1  -1 +1 +1  +1 -1 +1  +1 +1 -1}' #should depend on TmunuBase vars
+CCTK_REAL ccc_Tmunu type = GF CENTERING={ccc} TAGS='InterpNumTimelevels=1 prolongation="none" checkpoint="no" parity={ +1 +1 +1  +1 +1 +1  -1 +1 +1  +1 -1 +1  +1 +1 -1}' #should depend on TmunuBase vars
 {
   ccc_Ttt, ccc_Ttx, ccc_Tty, ccc_Ttz
   ccc_Txx, ccc_Txy, ccc_Txz
@@ -39,7 +39,7 @@ CCTK_REAL ccc_Tmunu type = GF CENTERING={ccc} TAGS='InterpNumTimelevels=1 prolon
 # The variables rho_b and pressure are identical to the HydroBase variables. However,
 # GRHayL uses the velocity v^i = u^i/u^0, while HydroBase uses the Valencia velocity, so
 # these velocities differ from HydroBase.
-CCTK_REAL grmhd_velocities type = GF CENTERING={ccc} TAGS='InterpNumTimelevels=1 prolongation="none"' #dependents="grmhd_conservatives" (not sure if this would mess up how c2p is designed)
+CCTK_REAL grmhd_velocities type = GF CENTERING={ccc} TAGS='InterpNumTimelevels=1 prolongation="none" checkpoint="no"' #dependents="grmhd_conservatives" (not sure if this would mess up how c2p is designed)
 {
   vx, vy, vz
 } "Components of primitive three velocity v^i. Note that v^i is defined in terms of 4-velocity as: v^i = u^i/u^0. Note that this definition differs from the Valencia formalism."

--- a/GRHayLHDX/schedule.ccl
+++ b/GRHayLHDX/schedule.ccl
@@ -74,7 +74,7 @@ schedule GRHayLHDX_compute_ccc_centered_spacetime_quantities in GRHayLHDX_Con2Pr
   LANG: C
   READS:  ADMBaseX::metric, ADMBaseX::lapse, ADMBaseX::shift
   WRITES: ccc_spacetime(everywhere)
-  SYNC: grmhd_conservatives #, Ye_star, ent_star
+  SYNC: grmhd_conservatives, Ye_star, ent_star
 } "Interpolate spacetime quantities to cell centers"
 
 if(perturb_every_con2prim) {
@@ -201,11 +201,10 @@ if (CCTK_Equals(EOS_type, "Hybrid") || CCTK_Equals(EOS_type, "Simple")) {
       READS:  ccc_spacetime,
               HydroBaseX::rho, HydroBaseX::press, HydroBaseX::eps,
               HydroBaseX::entropy, grmhd_velocities
-      WRITES: u0(everywhere), grmhd_velocities(everywhere),
-              grmhd_conservatives(everywhere), ent_star(everywhere),
+      WRITES: u0(everywhere), grmhd_velocities(everywhere), grmhd_conservatives(everywhere),
+              ent_star(everywhere), Ye_star(everywhere),
               HydroBaseX::rho(everywhere), HydroBaseX::press(everywhere),
               HydroBaseX::eps(everywhere), HydroBaseX::entropy(everywhere)
-      SYNC: grmhd_conservatives, ent_star
     } "Entropy+Hybrid version of GRHayLHDX_prims_to_conservs"
 
     schedule GRHayLHDX_hybrid_entropy_conservs_to_prims in GRHayLHDX_conservs_to_prims
@@ -268,8 +267,8 @@ if (CCTK_Equals(EOS_type, "Hybrid") || CCTK_Equals(EOS_type, "Simple")) {
       READS:  ccc_spacetime, HydroBaseX::rho, HydroBaseX::press, HydroBaseX::eps,
               grmhd_velocities
       WRITES: u0(everywhere), grmhd_velocities(everywhere), grmhd_conservatives(everywhere),
+              ent_star(everywhere), Ye_star(everywhere),
               HydroBaseX::rho(everywhere), HydroBaseX::press(everywhere), HydroBaseX::eps(everywhere)
-      SYNC: grmhd_conservatives
     } "Hybrid version of GRHayLHDX_prims_to_conservs"
 
     schedule GRHayLHDX_hybrid_conservs_to_prims in GRHayLHDX_conservs_to_prims
@@ -336,7 +335,6 @@ if (CCTK_Equals(EOS_type, "Hybrid") || CCTK_Equals(EOS_type, "Simple")) {
               ent_star(everywhere), Ye_star(everywhere),
               HydroBaseX::rho(everywhere), HydroBaseX::press(everywhere), HydroBaseX::eps(everywhere),
               HydroBaseX::entropy(everywhere), HydroBaseX::Ye(everywhere), HydroBaseX::temperature(everywhere)
-      SYNC: grmhd_conservatives, ent_star, Ye_star
     } "Entropy+Tabulated version of GRHayLHDX_prims_to_conservs"
 
     schedule GRHayLHDX_tabulated_entropy_conservs_to_prims in GRHayLHDX_conservs_to_prims
@@ -407,11 +405,10 @@ if (CCTK_Equals(EOS_type, "Hybrid") || CCTK_Equals(EOS_type, "Simple")) {
       READS:  HydroBaseX::rho, HydroBaseX::press, HydroBaseX::eps,
               HydroBaseX::Ye, HydroBaseX::temperature,
               grmhd_velocities
-      WRITES: u0(everywhere), grmhd_velocities(everywhere),
-              grmhd_conservatives(everywhere), Ye_star(everywhere),
+      WRITES: u0(everywhere), grmhd_velocities(everywhere), grmhd_conservatives(everywhere),
+              ent_star(everywhere), Ye_star(everywhere),
               HydroBaseX::rho(everywhere), HydroBaseX::press(everywhere), HydroBaseX::eps(everywhere),
               HydroBaseX::Ye(everywhere), HydroBaseX::temperature(everywhere)
-      SYNC: grmhd_conservatives, Ye_star
     } "Tabulated version of GRHayLHDX_prims_to_conservs"
 
     schedule GRHayLHDX_tabulated_conservs_to_prims in GRHayLHDX_conservs_to_prims

--- a/GRHayLHDX/src/Hybrid/prims_to_conservs.cxx
+++ b/GRHayLHDX/src/Hybrid/prims_to_conservs.cxx
@@ -54,5 +54,7 @@ extern "C" void GRHayLHDX_hybrid_prims_to_conservs(CCTK_ARGUMENTS) {
     Stildex(index)  = cons.SD[0];
     Stildey(index)  = cons.SD[1];
     Stildez(index)  = cons.SD[2];
+    ent_star(index) = 0.0; // FIXME: Required by CarpetX
+    Ye_star(index) = 0.0; // FIXME: Required by CarpetX
   }); // ccc loop everywhere
 }

--- a/GRHayLHDX/src/HybridEntropy/prims_to_conservs.cxx
+++ b/GRHayLHDX/src/HybridEntropy/prims_to_conservs.cxx
@@ -57,5 +57,6 @@ extern "C" void GRHayLHDX_hybrid_entropy_prims_to_conservs(CCTK_ARGUMENTS) {
     Stildey(index)  = cons.SD[1];
     Stildez(index)  = cons.SD[2];
     ent_star(index) = cons.entropy;
+    Ye_star(index) = 0.0; // FIXME: Required by CarpetX
   }); // ccc loop everywhere
 }

--- a/GRHayLHDX/src/Tabulated/prims_to_conservs.cxx
+++ b/GRHayLHDX/src/Tabulated/prims_to_conservs.cxx
@@ -58,6 +58,7 @@ extern "C" void GRHayLHDX_tabulated_prims_to_conservs(CCTK_ARGUMENTS) {
     Stildex(index)  = cons.SD[0];
     Stildey(index)  = cons.SD[1];
     Stildez(index)  = cons.SD[2];
+    ent_star(index) = 0.0; // FIXME: Required by CarpetX
     Ye_star(index)  = cons.Y_e;
   }); // ccc loop everywhere
 }


### PR DESCRIPTION
This PR fixes a scheduling issue due to CarpetX ignoring the 'STORAGE' specifications in schedule.ccl. Instead, according to Roland,  it allocates and check whether *all* gridfunctions are valid.

In words, the modifications always initialize Ye_star and ent_star to zero during prim2con. We also need to SYNC these gridfunctions to make sure they are valid on every time step, and we do that after the GRHayLHDX_compute_ccc_centered_spacetime_quantities function since the other conservatives were already synced there.

In the future, the changes above should be reverted, as the original schedule was correct.

In addition, this PR removes some unnecessary SYNCs and adds the 'checkpoint="no"' tag to several auxiliary gridfunctions in interface.ccl.