### PR TITLE
IGM: Changes to match cleanup branch of GRHayL

### DIFF
--- a/IllinoisGRMHD/src/A_flux_rhs.c
+++ b/IllinoisGRMHD/src/A_flux_rhs.c
@@ -42,7 +42,7 @@ void IllinoisGRMHD_A_flux_rhs(
         const int index_B1 = CCTK_GFINDEX3D(cctkGH,i+B1_offset[0],j+B1_offset[1],k+B1_offset[2]);
         const int index_B2 = CCTK_GFINDEX3D(cctkGH,i+B2_offset[0],j+B2_offset[1],k+B2_offset[2]);
 
-        HLL_vars vars;
+        ghl_HLL_vars vars;
 
         vars.v1rr = in_prims_r[VXR+dir1_offset][index_v];
         vars.v1rl = in_prims_l[VXR+dir1_offset][index_v];

--- a/IllinoisGRMHD/src/evaluate_phitilde_and_A_gauge_rhs.c
+++ b/IllinoisGRMHD/src/evaluate_phitilde_and_A_gauge_rhs.c
@@ -61,7 +61,7 @@ void IllinoisGRMHD_evaluate_phitilde_and_A_gauge_rhs(CCTK_ARGUMENTS) {
         CCTK_REAL Ax_stencil[3][3][3];
         CCTK_REAL Ay_stencil[3][3][3];
         CCTK_REAL Az_stencil[3][3][3];
-        induction_interp_vars interp_vars;
+        ghl_induction_interp_vars interp_vars;
 
         // Read in variable at interpolation stencil points from main memory.
         for(int iterz=0; iterz<2; iterz++)


### PR DESCRIPTION
The GRHayL [cleanup PR](https://github.com/GRHayL/GRHayL/pull/63) is mostly internal, but it adds the missing 'ghl_' to induction structs, which is matched to changes in IGM in this PR.