### PR TITLE
Fix IllinoisGRMHD/schedule.ccl evaluate_fluxes_rhs

### DIFF
--- a/IllinoisGRMHD/schedule.ccl
+++ b/IllinoisGRMHD/schedule.ccl
@@ -205,7 +205,7 @@ if(CCTK_IsThornActive("NRPyLeakageET"))
   } "Convert needed HydroBase variables for NRPyLeakage"
 }
 
-schedule IllinoisGRMHD_evaluate_phitilde_and_A_gauge_rhs in IllinoisGRMHD_RHS after evaluate_fluxes_rhs
+schedule IllinoisGRMHD_evaluate_phitilde_and_A_gauge_rhs in IllinoisGRMHD_RHS after IllinoisGRMHD_evaluate_fluxes_rhs
 {
   LANG: C
   READS:  ADMBase::lapse, ADMBase::shift, ADMBase::metric,


### PR DESCRIPTION
This PR addresses a scheduling issue in IGM raised by Fabrizio Venturi, where `schedule.ccl` uses 'evaluate_fluxes_rhs' instead of 'IllinoisGRMHD_evaluate_fluxes_rhs'.