### PR TITLE
GRHayLHDX: fixed multi-line comments that end in backslash

### DIFF
--- a/GRHayLHDX/src/Hybrid/conservs_to_prims.cxx
+++ b/GRHayLHDX/src/Hybrid/conservs_to_prims.cxx
@@ -21,10 +21,12 @@ extern "C" void GRHayLHDX_hybrid_conservs_to_prims(CCTK_ARGUMENTS) {
   const Loop::GF3D2layout layout(cctkGH, {1, 1, 1});
 
 //I don't think I can do this sort of diagnostic summing in carpetx
-//#pragma omp parallel for reduction(+: \
-//      pointcount, backup0, backup1, backup2, vel_limited_ptcount, rho_star_fix_applied, failures, failures_inhoriz, pointcount_inhoriz, n_iter, \
-//      error_rho_numer, error_tau_numer, error_Sx_numer, error_Sy_numer, error_Sz_numer, error_entropy_numer, error_Ye_numer,                    \
-//      error_rho_denom, error_tau_denom, error_Sx_denom, error_Sy_denom, error_Sz_denom, error_entropy_denom, error_Ye_denom) schedule(static)
+/*
+#pragma omp parallel for reduction(+: \
+      pointcount, backup0, backup1, backup2, vel_limited_ptcount, rho_star_fix_applied, failures, failures_inhoriz, pointcount_inhoriz, n_iter, \
+      error_rho_numer, error_tau_numer, error_Sx_numer, error_Sy_numer, error_Sz_numer, error_entropy_numer, error_Ye_numer,                    \
+      error_rho_denom, error_tau_denom, error_Sx_denom, error_Sy_denom, error_Sz_denom, error_entropy_denom, error_Ye_denom) schedule(static)
+*/
   grid.loop_all<1, 1, 1>(
       grid.nghostzones,
       [=] CCTK_HOST(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {

--- a/GRHayLHDX/src/HybridEntropy/conservs_to_prims.cxx
+++ b/GRHayLHDX/src/HybridEntropy/conservs_to_prims.cxx
@@ -21,10 +21,12 @@ extern "C" void GRHayLHDX_hybrid_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
   const Loop::GF3D2layout layout(cctkGH, {1, 1, 1});
 
 //I don't think I can do this sort of diagnostic summing in carpetx
-//#pragma omp parallel for reduction(+: \
-//      pointcount, backup0, backup1, backup2, vel_limited_ptcount, rho_star_fix_applied, failures, failures_inhoriz, pointcount_inhoriz, n_iter, \
-//      error_rho_numer, error_tau_numer, error_Sx_numer, error_Sy_numer, error_Sz_numer, error_entropy_numer, error_Ye_numer,                    \
-//      error_rho_denom, error_tau_denom, error_Sx_denom, error_Sy_denom, error_Sz_denom, error_entropy_denom, error_Ye_denom) schedule(static)
+/*
+#pragma omp parallel for reduction(+: \
+      pointcount, backup0, backup1, backup2, vel_limited_ptcount, rho_star_fix_applied, failures, failures_inhoriz, pointcount_inhoriz, n_iter, \
+      error_rho_numer, error_tau_numer, error_Sx_numer, error_Sy_numer, error_Sz_numer, error_entropy_numer, error_Ye_numer,                    \
+      error_rho_denom, error_tau_denom, error_Sx_denom, error_Sy_denom, error_Sz_denom, error_entropy_denom, error_Ye_denom) schedule(static)
+*/
   grid.loop_all<1, 1, 1>(
       grid.nghostzones,
       [=] CCTK_HOST(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {

--- a/GRHayLHDX/src/Tabulated/conservs_to_prims.cxx
+++ b/GRHayLHDX/src/Tabulated/conservs_to_prims.cxx
@@ -21,10 +21,12 @@ extern "C" void GRHayLHDX_tabulated_conservs_to_prims(CCTK_ARGUMENTS) {
   const Loop::GF3D2layout layout(cctkGH, {1, 1, 1});
 
 //I don't think I can do this sort of diagnostic summing in carpetx
-//#pragma omp parallel for reduction(+: \
-//      pointcount, backup0, backup1, backup2, vel_limited_ptcount, rho_star_fix_applied, failures, failures_inhoriz, pointcount_inhoriz, n_iter, \
-//      error_rho_numer, error_tau_numer, error_Sx_numer, error_Sy_numer, error_Sz_numer, error_entropy_numer, error_Ye_numer,                    \
-//      error_rho_denom, error_tau_denom, error_Sx_denom, error_Sy_denom, error_Sz_denom, error_entropy_denom, error_Ye_denom) schedule(static)
+/*
+#pragma omp parallel for reduction(+: \
+      pointcount, backup0, backup1, backup2, vel_limited_ptcount, rho_star_fix_applied, failures, failures_inhoriz, pointcount_inhoriz, n_iter, \
+      error_rho_numer, error_tau_numer, error_Sx_numer, error_Sy_numer, error_Sz_numer, error_entropy_numer, error_Ye_numer,                    \
+      error_rho_denom, error_tau_denom, error_Sx_denom, error_Sy_denom, error_Sz_denom, error_entropy_denom, error_Ye_denom) schedule(static)
+*/
   grid.loop_all<1, 1, 1>(
       grid.nghostzones,
       [=] CCTK_HOST(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {

--- a/GRHayLHDX/src/TabulatedEntropy/conservs_to_prims.cxx
+++ b/GRHayLHDX/src/TabulatedEntropy/conservs_to_prims.cxx
@@ -21,10 +21,12 @@ extern "C" void GRHayLHDX_tabulated_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
   const Loop::GF3D2layout layout(cctkGH, {1, 1, 1});
 
 //I don't think I can do this sort of diagnostic summing in carpetx
-//#pragma omp parallel for reduction(+: \
-//      pointcount, backup0, backup1, backup2, vel_limited_ptcount, rho_star_fix_applied, failures, failures_inhoriz, pointcount_inhoriz, n_iter, \
-//      error_rho_numer, error_tau_numer, error_Sx_numer, error_Sy_numer, error_Sz_numer, error_entropy_numer, error_Ye_numer,                    \
-//      error_rho_denom, error_tau_denom, error_Sx_denom, error_Sy_denom, error_Sz_denom, error_entropy_denom, error_Ye_denom) schedule(static)
+/*
+#pragma omp parallel for reduction(+: \
+      pointcount, backup0, backup1, backup2, vel_limited_ptcount, rho_star_fix_applied, failures, failures_inhoriz, pointcount_inhoriz, n_iter, \
+      error_rho_numer, error_tau_numer, error_Sx_numer, error_Sy_numer, error_Sz_numer, error_entropy_numer, error_Ye_numer,                    \
+      error_rho_denom, error_tau_denom, error_Sx_denom, error_Sy_denom, error_Sz_denom, error_entropy_denom, error_Ye_denom) schedule(static)
+*/
   grid.loop_all<1, 1, 1>(
       grid.nghostzones,
       [=] CCTK_HOST(const Loop::PointDesc &p) CCTK_ATTRIBUTE_ALWAYS_INLINE {


### PR DESCRIPTION
This PR fixes multi-line C++-style comments (i.e., `//`) that end in a backslash, replacing the comment block with a multi-line comment (i.e., `/* ... */`).