### PR TITLE
New tabulated eos reader

### DIFF
--- a/GRHayLHD/src/Hybrid/conservs_to_prims.c
+++ b/GRHayLHD/src/Hybrid/conservs_to_prims.c
@@ -216,8 +216,7 @@ void GRHayLHD_hybrid_conservs_to_prims(CCTK_ARGUMENTS) {
         // Enforce limits on primitive variables and recompute conservatives.
         error = ghl_enforce_primitive_limits_and_compute_u0(
               ghl_params, ghl_eos, &ADM_metric, &prims, &diagnostics.speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         rho[index]   = prims.rho;
         press[index] = prims.press;

--- a/GRHayLHD/src/Hybrid/evaluate_fluxes_rhs.c
+++ b/GRHayLHD/src/Hybrid/evaluate_fluxes_rhs.c
@@ -111,11 +111,10 @@ void GRHayLHD_hybrid_evaluate_fluxes_rhs(CCTK_ARGUMENTS) {
 
           bool speed_limited;
           ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
-          if(error)
-            ghl_read_error_codes(error);
+          ghl_abort_if_error(error);
+
           error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
-          if(error)
-            ghl_read_error_codes(error);
+          ghl_abort_if_error(error);
 
           CCTK_REAL cmin, cmax;
           ghl_conservative_quantities cons_fluxes;

--- a/GRHayLHD/src/Hybrid/evaluate_sources_rhs.c
+++ b/GRHayLHD/src/Hybrid/evaluate_sources_rhs.c
@@ -47,8 +47,7 @@ void GRHayLHD_hybrid_evaluate_sources_rhs(CCTK_ARGUMENTS) {
 
         bool speed_limited;
         ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         ghl_metric_quantities ADM_metric_derivs_x;
         GRHayLHD_compute_metric_derivs(

--- a/GRHayLHD/src/Hybrid/outer_boundaries.c
+++ b/GRHayLHD/src/Hybrid/outer_boundaries.c
@@ -189,15 +189,13 @@ void GRHayLHD_hybrid_enforce_primitive_limits_and_compute_conservs(const cGH* cc
   ghl_ADM_aux_quantities metric_aux;
   ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
 
-  bool speed_limited;
+  bool speed_limited = false;
   ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
         ghl_params, ghl_eos, &ADM_metric, prims, &speed_limited);
-  if(error)
-    ghl_read_error_codes(error);
+  ghl_abort_if_error(error);
 
   ghl_conservative_quantities cons;
-  ghl_compute_conservs(
-        &ADM_metric, &metric_aux, prims, &cons);
+  ghl_compute_conservs(&ADM_metric, &metric_aux, prims, &cons);
 
   rho[index]   = prims->rho;
   press[index] = prims->press;

--- a/GRHayLHD/src/Hybrid/prims_to_conservs.c
+++ b/GRHayLHD/src/Hybrid/prims_to_conservs.c
@@ -33,15 +33,13 @@ void GRHayLHD_hybrid_prims_to_conservs(CCTK_ARGUMENTS) {
         prims.vU[1] = vy[index];
         prims.vU[2] = vz[index];
 
-        bool speed_limited; 
+        bool speed_limited = false;
         const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
               ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         ghl_conservative_quantities cons;
-        ghl_compute_conservs(
-              &ADM_metric, &metric_aux, &prims, &cons);
+        ghl_compute_conservs(&ADM_metric, &metric_aux, &prims, &cons);
 
         rho[index]   = prims.rho;
         press[index] = prims.press;

--- a/GRHayLHD/src/HybridEntropy/conservs_to_prims.c
+++ b/GRHayLHD/src/HybridEntropy/conservs_to_prims.c
@@ -226,8 +226,7 @@ void GRHayLHD_hybrid_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
         // Enforce limits on primitive variables and recompute conservatives.
         error = ghl_enforce_primitive_limits_and_compute_u0(
               ghl_params, ghl_eos, &ADM_metric, &prims, &diagnostics.speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         rho[index]     = prims.rho;
         press[index]   = prims.press;

--- a/GRHayLHD/src/HybridEntropy/evaluate_fluxes_rhs.c
+++ b/GRHayLHD/src/HybridEntropy/evaluate_fluxes_rhs.c
@@ -112,13 +112,12 @@ void GRHayLHD_hybrid_entropy_evaluate_fluxes_rhs(CCTK_ARGUMENTS) {
           prims_r.BU[0] = prims_r.BU[1] = prims_r.BU[2] = 0.0;
           prims_l.BU[0] = prims_l.BU[1] = prims_l.BU[2] = 0.0;
 
-          bool speed_limited;
+          bool speed_limited = false;
           ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
-          if(error)
-            ghl_read_error_codes(error);
+          ghl_abort_if_error(error);
+
           error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
-          if(error)
-            ghl_read_error_codes(error);
+          ghl_abort_if_error(error);
 
           CCTK_REAL cmin, cmax;
           ghl_conservative_quantities cons_fluxes;

--- a/GRHayLHD/src/HybridEntropy/evaluate_sources_rhs.c
+++ b/GRHayLHD/src/HybridEntropy/evaluate_sources_rhs.c
@@ -47,10 +47,9 @@ void GRHayLHD_hybrid_entropy_evaluate_sources_rhs(CCTK_ARGUMENTS) {
         prims.vU[2] = vz[index];
         prims.entropy = entropy[index];
 
-        bool speed_limited;
+        bool speed_limited = false;
         ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         ghl_metric_quantities ADM_metric_derivs_x;
         GRHayLHD_compute_metric_derivs(

--- a/GRHayLHD/src/HybridEntropy/outer_boundaries.c
+++ b/GRHayLHD/src/HybridEntropy/outer_boundaries.c
@@ -195,15 +195,13 @@ void GRHayLHD_hybrid_entropy_enforce_primitive_limits_and_compute_conservs(const
   ghl_ADM_aux_quantities metric_aux;
   ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
 
-  bool speed_limited;
+  bool speed_limited = false;
   ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
         ghl_params, ghl_eos, &ADM_metric, prims, &speed_limited);
-  if(error)
-    ghl_read_error_codes(error);
+  ghl_abort_if_error(error);
 
   ghl_conservative_quantities cons;
-  ghl_compute_conservs(
-        &ADM_metric, &metric_aux, prims, &cons);
+  ghl_compute_conservs(&ADM_metric, &metric_aux, prims, &cons);
 
   rho[index]     = prims->rho;
   press[index]   = prims->press;

--- a/GRHayLHD/src/HybridEntropy/prims_to_conservs.c
+++ b/GRHayLHD/src/HybridEntropy/prims_to_conservs.c
@@ -34,15 +34,13 @@ void GRHayLHD_hybrid_entropy_prims_to_conservs(CCTK_ARGUMENTS) {
         prims.vU[2]   = vz[index];
         prims.entropy = entropy[index];
 
-        bool speed_limited; 
+        bool speed_limited = false;
         const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
               ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         ghl_conservative_quantities cons;
-        ghl_compute_conservs(
-              &ADM_metric, &metric_aux, &prims, &cons);
+        ghl_compute_conservs(&ADM_metric, &metric_aux, &prims, &cons);
 
         rho[index]     = prims.rho;
         press[index]   = prims.press;

--- a/GRHayLHD/src/Tabulated/conservs_to_prims.c
+++ b/GRHayLHD/src/Tabulated/conservs_to_prims.c
@@ -194,8 +194,7 @@ void GRHayLHD_tabulated_conservs_to_prims(CCTK_ARGUMENTS) {
         // Enforce limits on primitive variables and recompute conservatives.
         error = ghl_enforce_primitive_limits_and_compute_u0(
               ghl_params, ghl_eos, &ADM_metric, &prims, &diagnostics.speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         rho[index]         = prims.rho;
         press[index]       = prims.press;

--- a/GRHayLHD/src/Tabulated/evaluate_fluxes_rhs.c
+++ b/GRHayLHD/src/Tabulated/evaluate_fluxes_rhs.c
@@ -104,13 +104,12 @@ void GRHayLHD_tabulated_evaluate_fluxes_rhs(CCTK_ARGUMENTS) {
 
           prims_r.temperature = prims_l.temperature = temperature[index];
 
-          bool speed_limited;
+          bool speed_limited = false;
           ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
-          if(error)
-            ghl_read_error_codes(error);
+          ghl_abort_if_error(error);
+
           error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
-          if(error)
-            ghl_read_error_codes(error);
+          ghl_abort_if_error(error);
 
           // We must now compute eps and T
           ghl_tabulated_enforce_bounds_rho_Ye_P(ghl_eos, &prims_r.rho, &prims_r.Y_e, &prims_r.press);

--- a/GRHayLHD/src/Tabulated/evaluate_sources_rhs.c
+++ b/GRHayLHD/src/Tabulated/evaluate_sources_rhs.c
@@ -48,10 +48,9 @@ void GRHayLHD_tabulated_evaluate_sources_rhs(CCTK_ARGUMENTS) {
         prims.Y_e         = Y_e[index];
         prims.temperature = temperature[index];
 
-        bool speed_limited;
+        bool speed_limited = false;
         ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         ghl_metric_quantities ADM_metric_derivs_x;
         GRHayLHD_compute_metric_derivs(

--- a/GRHayLHD/src/Tabulated/outer_boundaries.c
+++ b/GRHayLHD/src/Tabulated/outer_boundaries.c
@@ -201,15 +201,13 @@ void GRHayLHD_tabulated_enforce_primitive_limits_and_compute_conservs(const cGH*
   ghl_ADM_aux_quantities metric_aux;
   ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
 
-  bool speed_limited;
+  bool speed_limited = false;
   ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
         ghl_params, ghl_eos, &ADM_metric, prims, &speed_limited);
-  if(error)
-    ghl_read_error_codes(error);
+  ghl_abort_if_error(error);
 
   ghl_conservative_quantities cons;
-  ghl_compute_conservs(
-        &ADM_metric, &metric_aux, prims, &cons);
+  ghl_compute_conservs(&ADM_metric, &metric_aux, prims, &cons);
 
   rho[index]         = prims->rho;
   press[index]       = prims->press;

--- a/GRHayLHD/src/Tabulated/prims_to_conservs.c
+++ b/GRHayLHD/src/Tabulated/prims_to_conservs.c
@@ -35,15 +35,13 @@ void GRHayLHD_tabulated_prims_to_conservs(CCTK_ARGUMENTS) {
         prims.Y_e         = Y_e[index];
         prims.temperature = temperature[index];
 
-        bool speed_limited; 
+        bool speed_limited = false;
         const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
               ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         ghl_conservative_quantities cons;
-        ghl_compute_conservs(
-              &ADM_metric, &metric_aux, &prims, &cons);
+        ghl_compute_conservs(&ADM_metric, &metric_aux, &prims, &cons);
 
         rho[index]         = prims.rho;
         press[index]       = prims.press;

--- a/GRHayLHD/src/TabulatedEntropy/conservs_to_prims.c
+++ b/GRHayLHD/src/TabulatedEntropy/conservs_to_prims.c
@@ -200,8 +200,7 @@ void GRHayLHD_tabulated_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
         // Enforce limits on primitive variables and recompute conservatives.
         error = ghl_enforce_primitive_limits_and_compute_u0(
               ghl_params, ghl_eos, &ADM_metric, &prims, &diagnostics.speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         rho[index]         = prims.rho;
         press[index]       = prims.press;

--- a/GRHayLHD/src/TabulatedEntropy/evaluate_fluxes_rhs.c
+++ b/GRHayLHD/src/TabulatedEntropy/evaluate_fluxes_rhs.c
@@ -106,13 +106,12 @@ void GRHayLHD_tabulated_entropy_evaluate_fluxes_rhs(CCTK_ARGUMENTS) {
 
           prims_r.temperature = prims_l.temperature = temperature[index];
 
-          bool speed_limited;
+          bool speed_limited = false;
           ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
-          if(error)
-            ghl_read_error_codes(error);
+          ghl_abort_if_error(error);
+
           error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
-          if(error)
-            ghl_read_error_codes(error);
+          ghl_abort_if_error(error);
 
           // We must now compute eps and T
           ghl_tabulated_enforce_bounds_rho_Ye_P(ghl_eos, &prims_r.rho, &prims_r.Y_e, &prims_r.press);

--- a/GRHayLHD/src/TabulatedEntropy/evaluate_sources_rhs.c
+++ b/GRHayLHD/src/TabulatedEntropy/evaluate_sources_rhs.c
@@ -50,10 +50,9 @@ void GRHayLHD_tabulated_entropy_evaluate_sources_rhs(CCTK_ARGUMENTS) {
         prims.Y_e         = Y_e[index];
         prims.temperature = temperature[index];
 
-        bool speed_limited;
+        bool speed_limited = false;
         ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         ghl_metric_quantities ADM_metric_derivs_x;
         GRHayLHD_compute_metric_derivs(

--- a/GRHayLHD/src/TabulatedEntropy/outer_boundaries.c
+++ b/GRHayLHD/src/TabulatedEntropy/outer_boundaries.c
@@ -207,15 +207,13 @@ void GRHayLHD_tabulated_entropy_enforce_primitive_limits_and_compute_conservs(co
   ghl_ADM_aux_quantities metric_aux;
   ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
 
-  bool speed_limited;
+  bool speed_limited = false;
   ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
         ghl_params, ghl_eos, &ADM_metric, prims, &speed_limited);
-  if(error)
-    ghl_read_error_codes(error);
+  ghl_abort_if_error(error);
 
   ghl_conservative_quantities cons;
-  ghl_compute_conservs(
-        &ADM_metric, &metric_aux, prims, &cons);
+  ghl_compute_conservs(&ADM_metric, &metric_aux, prims, &cons);
 
   rho[index]         = prims->rho;
   press[index]       = prims->press;

--- a/GRHayLHD/src/TabulatedEntropy/prims_to_conservs.c
+++ b/GRHayLHD/src/TabulatedEntropy/prims_to_conservs.c
@@ -36,15 +36,13 @@ void GRHayLHD_tabulated_entropy_prims_to_conservs(CCTK_ARGUMENTS) {
         prims.Y_e         = Y_e[index];
         prims.temperature = temperature[index];
 
-        bool speed_limited; 
+        bool speed_limited = false;
         const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
               ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         ghl_conservative_quantities cons;
-        ghl_compute_conservs(
-              &ADM_metric, &metric_aux, &prims, &cons);
+        ghl_compute_conservs(&ADM_metric, &metric_aux, &prims, &cons);
 
         rho[index]         = prims.rho;
         press[index]       = prims.press;

--- a/GRHayLHDX/src/Hybrid/conservs_to_prims.cxx
+++ b/GRHayLHDX/src/Hybrid/conservs_to_prims.cxx
@@ -126,11 +126,9 @@ extern "C" void GRHayLHDX_hybrid_conservs_to_prims(CCTK_ARGUMENTS) {
     //--------------------------------------------------
     error = ghl_enforce_primitive_limits_and_compute_u0(
           ghl_params, ghl_eos, &ADM_metric, &prims, &diagnostics.speed_limited);
-    if(error)
-      ghl_read_error_codes(error);
+    ghl_abort_if_error(error);
 
-    ghl_compute_conservs(
-          &ADM_metric, &metric_aux, &prims, &cons);
+    ghl_compute_conservs(&ADM_metric, &metric_aux, &prims, &cons);
 
     rho(index)   = prims.rho;
     press(index) = prims.press;

--- a/GRHayLHDX/src/Hybrid/evaluate_fluxes.cxx
+++ b/GRHayLHDX/src/Hybrid/evaluate_fluxes.cxx
@@ -107,13 +107,12 @@ void GRHayLHDX_hybrid_evaluate_fluxes_dir(CCTK_ARGUMENTS) {
     prims_r.BU[0] = prims_r.BU[1] = prims_r.BU[2] = 0.0;
     prims_l.BU[0] = prims_l.BU[1] = prims_l.BU[2] = 0.0;
 
-    bool speed_limited;
+    bool speed_limited = false;
     ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
-    if(error)
-      ghl_read_error_codes(error);
+    ghl_abort_if_error(error);
+
     error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
-    if(error)
-      ghl_read_error_codes(error);
+    ghl_abort_if_error(error);
 
     CCTK_REAL cmin, cmax;
     ghl_conservative_quantities cons_fluxes;

--- a/GRHayLHDX/src/Hybrid/evaluate_sources_rhs.cxx
+++ b/GRHayLHDX/src/Hybrid/evaluate_sources_rhs.cxx
@@ -40,10 +40,9 @@ void GRHayLHDX_hybrid_evaluate_sources_rhs(CCTK_ARGUMENTS) {
     prims.vU[1] = vy(index);
     prims.vU[2] = vz(index);
 
-    bool speed_limited;
+    bool speed_limited = false;
     ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
-    if(error)
-      ghl_read_error_codes(error);
+    ghl_abort_if_error(error);
 
     const Loop::GF3D2index indm2x(layout, p.I - 2*p.DI[0]);
     const Loop::GF3D2index indm1x(layout, p.I -   p.DI[0]);

--- a/GRHayLHDX/src/Hybrid/prims_to_conservs.cxx
+++ b/GRHayLHDX/src/Hybrid/prims_to_conservs.cxx
@@ -31,15 +31,13 @@ extern "C" void GRHayLHDX_hybrid_prims_to_conservs(CCTK_ARGUMENTS) {
     prims.vU[1] = vy(index);
     prims.vU[2] = vz(index);
 
-    bool speed_limited; 
+    bool speed_limited = false;
     const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
           ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
-    if(error)
-      ghl_read_error_codes(error);
+    ghl_abort_if_error(error);
 
     ghl_conservative_quantities cons;
-    ghl_compute_conservs(
-          &ADM_metric, &metric_aux, &prims, &cons);
+    ghl_compute_conservs(&ADM_metric, &metric_aux, &prims, &cons);
 
     rho(index)   = prims.rho;
     press(index) = prims.press;

--- a/GRHayLHDX/src/HybridEntropy/conservs_to_prims.cxx
+++ b/GRHayLHDX/src/HybridEntropy/conservs_to_prims.cxx
@@ -128,11 +128,9 @@ extern "C" void GRHayLHDX_hybrid_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
     //--------------------------------------------------
     error = ghl_enforce_primitive_limits_and_compute_u0(
           ghl_params, ghl_eos, &ADM_metric, &prims, &diagnostics.speed_limited);
-    if(error)
-      ghl_read_error_codes(error);
+    ghl_abort_if_error(error);
 
-    ghl_compute_conservs(
-          &ADM_metric, &metric_aux, &prims, &cons);
+    ghl_compute_conservs(&ADM_metric, &metric_aux, &prims, &cons);
 
     rho(index)     = prims.rho;
     press(index)   = prims.press;

--- a/GRHayLHDX/src/HybridEntropy/evaluate_fluxes.cxx
+++ b/GRHayLHDX/src/HybridEntropy/evaluate_fluxes.cxx
@@ -113,13 +113,12 @@ void GRHayLHDX_hybrid_entropy_evaluate_fluxes_dir(CCTK_ARGUMENTS) {
     prims_r.BU[0] = prims_r.BU[1] = prims_r.BU[2] = 0.0;
     prims_l.BU[0] = prims_l.BU[1] = prims_l.BU[2] = 0.0;
 
-    bool speed_limited;
+    bool speed_limited = false;
     ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
-    if(error)
-      ghl_read_error_codes(error);
+    ghl_abort_if_error(error);
+
     error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
-    if(error)
-      ghl_read_error_codes(error);
+    ghl_abort_if_error(error);
 
     CCTK_REAL cmin, cmax;
     ghl_conservative_quantities cons_fluxes;

--- a/GRHayLHDX/src/HybridEntropy/evaluate_sources_rhs.cxx
+++ b/GRHayLHDX/src/HybridEntropy/evaluate_sources_rhs.cxx
@@ -42,10 +42,9 @@ void GRHayLHDX_hybrid_entropy_evaluate_sources_rhs(CCTK_ARGUMENTS) {
     prims.vU[2]   = vz(index);
     prims.entropy = entropy(index);
 
-    bool speed_limited;
+    bool speed_limited = false;
     ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
-    if(error)
-      ghl_read_error_codes(error);
+    ghl_abort_if_error(error);
 
     const Loop::GF3D2index indm2x(layout, p.I - 2*p.DI[0]);
     const Loop::GF3D2index indm1x(layout, p.I -   p.DI[0]);

--- a/GRHayLHDX/src/HybridEntropy/prims_to_conservs.cxx
+++ b/GRHayLHDX/src/HybridEntropy/prims_to_conservs.cxx
@@ -32,15 +32,13 @@ extern "C" void GRHayLHDX_hybrid_entropy_prims_to_conservs(CCTK_ARGUMENTS) {
     prims.vU[2]   = vz(index);
     prims.entropy = entropy(index);
 
-    bool speed_limited; 
+    bool speed_limited = false;
     const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
           ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
-    if(error)
-      ghl_read_error_codes(error);
+    ghl_abort_if_error(error);
 
     ghl_conservative_quantities cons;
-    ghl_compute_conservs(
-          &ADM_metric, &metric_aux, &prims, &cons);
+    ghl_compute_conservs(&ADM_metric, &metric_aux, &prims, &cons);
 
     rho(index)     = prims.rho;
     press(index)   = prims.press;

--- a/GRHayLHDX/src/Tabulated/conservs_to_prims.cxx
+++ b/GRHayLHDX/src/Tabulated/conservs_to_prims.cxx
@@ -105,11 +105,9 @@ extern "C" void GRHayLHDX_tabulated_conservs_to_prims(CCTK_ARGUMENTS) {
     //--------------------------------------------------
     error = ghl_enforce_primitive_limits_and_compute_u0(
           ghl_params, ghl_eos, &ADM_metric, &prims, &diagnostics.speed_limited);
-    if(error)
-      ghl_read_error_codes(error);
+    ghl_abort_if_error(error);
 
-    ghl_compute_conservs(
-          &ADM_metric, &metric_aux, &prims, &cons);
+    ghl_compute_conservs(&ADM_metric, &metric_aux, &prims, &cons);
 
     rho(index)         = prims.rho;
     press(index)       = prims.press;

--- a/GRHayLHDX/src/Tabulated/evaluate_fluxes.cxx
+++ b/GRHayLHDX/src/Tabulated/evaluate_fluxes.cxx
@@ -105,13 +105,12 @@ void GRHayLHDX_tabulated_evaluate_fluxes_dir(CCTK_ARGUMENTS) {
 
     prims_r.temperature = prims_l.temperature = temperature(index);
 
-    bool speed_limited;
+    bool speed_limited = false;
     ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
-    if(error)
-      ghl_read_error_codes(error);
+    ghl_abort_if_error(error);
+
     error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
-    if(error)
-      ghl_read_error_codes(error);
+    ghl_abort_if_error(error);
 
     // We must now compute eps and T
     ghl_tabulated_enforce_bounds_rho_Ye_P(ghl_eos, &prims_r.rho, &prims_r.Y_e, &prims_r.press);

--- a/GRHayLHDX/src/Tabulated/evaluate_sources_rhs.cxx
+++ b/GRHayLHDX/src/Tabulated/evaluate_sources_rhs.cxx
@@ -43,10 +43,9 @@ void GRHayLHDX_tabulated_evaluate_sources_rhs(CCTK_ARGUMENTS) {
     prims.Y_e         = Ye(index);
     prims.temperature = temperature(index);
 
-    bool speed_limited;
+    bool speed_limited = false;
     ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
-    if(error)
-      ghl_read_error_codes(error);
+    ghl_abort_if_error(error);
 
     const Loop::GF3D2index indm2x(layout, p.I - 2*p.DI[0]);
     const Loop::GF3D2index indm1x(layout, p.I -   p.DI[0]);

--- a/GRHayLHDX/src/Tabulated/prims_to_conservs.cxx
+++ b/GRHayLHDX/src/Tabulated/prims_to_conservs.cxx
@@ -33,15 +33,13 @@ extern "C" void GRHayLHDX_tabulated_prims_to_conservs(CCTK_ARGUMENTS) {
     prims.Y_e         = Ye(index);
     prims.temperature = temperature(index);
 
-    bool speed_limited; 
+    bool speed_limited = false;
     const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
           ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
-    if(error)
-      ghl_read_error_codes(error);
+    ghl_abort_if_error(error);
 
     ghl_conservative_quantities cons;
-    ghl_compute_conservs(
-          &ADM_metric, &metric_aux, &prims, &cons);
+    ghl_compute_conservs(&ADM_metric, &metric_aux, &prims, &cons);
 
     rho(index)         = prims.rho;
     press(index)       = prims.press;

--- a/GRHayLHDX/src/TabulatedEntropy/conservs_to_prims.cxx
+++ b/GRHayLHDX/src/TabulatedEntropy/conservs_to_prims.cxx
@@ -106,11 +106,9 @@ extern "C" void GRHayLHDX_tabulated_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
     //--------------------------------------------------
     error = ghl_enforce_primitive_limits_and_compute_u0(
           ghl_params, ghl_eos, &ADM_metric, &prims, &diagnostics.speed_limited);
-    if(error)
-      ghl_read_error_codes(error);
+    ghl_abort_if_error(error);
 
-    ghl_compute_conservs(
-          &ADM_metric, &metric_aux, &prims, &cons);
+    ghl_compute_conservs(&ADM_metric, &metric_aux, &prims, &cons);
 
     rho(index)         = prims.rho;
     press(index)       = prims.press;

--- a/GRHayLHDX/src/TabulatedEntropy/evaluate_fluxes.cxx
+++ b/GRHayLHDX/src/TabulatedEntropy/evaluate_fluxes.cxx
@@ -110,13 +110,12 @@ void GRHayLHDX_tabulated_entropy_evaluate_fluxes_dir(CCTK_ARGUMENTS) {
 
     prims_r.temperature = prims_l.temperature = temperature(index);
 
-    bool speed_limited;
+    bool speed_limited = false;
     ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
-    if(error)
-      ghl_read_error_codes(error);
+    ghl_abort_if_error(error);
+
     error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
-    if(error)
-      ghl_read_error_codes(error);
+    ghl_abort_if_error(error);
 
     // We must now compute eps and T
     ghl_tabulated_enforce_bounds_rho_Ye_P(ghl_eos, &prims_r.rho, &prims_r.Y_e, &prims_r.press);

--- a/GRHayLHDX/src/TabulatedEntropy/evaluate_sources_rhs.cxx
+++ b/GRHayLHDX/src/TabulatedEntropy/evaluate_sources_rhs.cxx
@@ -45,10 +45,9 @@ void GRHayLHDX_tabulated_entropy_evaluate_sources_rhs(CCTK_ARGUMENTS) {
     prims.Y_e         = Ye(index);
     prims.temperature = temperature(index);
 
-    bool speed_limited;
+    bool speed_limited = false;
     ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
-    if(error)
-      ghl_read_error_codes(error);
+    ghl_abort_if_error(error);
 
     const Loop::GF3D2index indm2x(layout, p.I - 2*p.DI[0]);
     const Loop::GF3D2index indm1x(layout, p.I -   p.DI[0]);

--- a/GRHayLHDX/src/TabulatedEntropy/prims_to_conservs.cxx
+++ b/GRHayLHDX/src/TabulatedEntropy/prims_to_conservs.cxx
@@ -34,15 +34,13 @@ extern "C" void GRHayLHDX_tabulated_entropy_prims_to_conservs(CCTK_ARGUMENTS) {
     prims.Y_e         = Ye(index);
     prims.temperature = temperature(index);
 
-    bool speed_limited; 
+    bool speed_limited = false;
     const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
           ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
-    if(error)
-      ghl_read_error_codes(error);
+    ghl_abort_if_error(error);
 
     ghl_conservative_quantities cons;
-    ghl_compute_conservs(
-          &ADM_metric, &metric_aux, &prims, &cons);
+    ghl_compute_conservs(&ADM_metric, &metric_aux, &prims, &cons);
 
     rho(index)         = prims.rho;
     press(index)       = prims.press;

--- a/GRHayLID/src/BetaEquilibrium.c
+++ b/GRHayLID/src/BetaEquilibrium.c
@@ -1,6 +1,6 @@
 #include "GRHayLID.h"
 
-void GRHayLID_BetaEquilibrium( CCTK_ARGUMENTS ) {
+void GRHayLID_BetaEquilibrium(CCTK_ARGUMENTS) {
 
   CCTK_INFO("Starting routine to impose neutrino free beta-equilibrium");
 
@@ -32,10 +32,18 @@ void GRHayLID_BetaEquilibrium( CCTK_ARGUMENTS ) {
           temperature[index] = ghl_eos->T_atm;
         } else {
           const double tempL = beq_temperature;
-          const double YeL   = ghl_tabulated_compute_Ye_from_rho(ghl_eos, rhoL);
+          double YeL = 0.0, pressL = 0.0, epsL = 0.0;
+          ghl_error_codes_t err = ghl_success;
 
-          double pressL, epsL;
-          ghl_tabulated_compute_P_eps_from_T(ghl_eos, rhoL, YeL, tempL, &pressL, &epsL);
+          err = ghl_tabulated_compute_Ye_from_rho(ghl_eos, rhoL, &YeL);
+          if(err != ghl_success) {
+            CCTK_ERROR("ghl_tabulated_compute_Ye_from_rho failed.");
+          }
+
+          err = ghl_tabulated_compute_P_eps_from_T(ghl_eos, rhoL, YeL, tempL, &pressL, &epsL);
+          if(err != ghl_success) {
+            CCTK_ERROR("ghl_tabulated_compute_P_eps_from_T failed.");
+          }
 
           press      [index] = pressL;
           eps        [index] = epsL;

--- a/GRHayLID/src/BetaEquilibrium.c
+++ b/GRHayLID/src/BetaEquilibrium.c
@@ -16,7 +16,9 @@ void GRHayLID_BetaEquilibrium(CCTK_ARGUMENTS) {
 
   CHECK_PARAMETER(beq_temperature);
 
-  ghl_tabulated_compute_Ye_of_rho_beq_constant_T(beq_temperature, ghl_eos);
+  ghl_error_codes_t err = ghl_success;
+  err = ghl_tabulated_compute_Ye_of_rho_beq_constant_T(beq_temperature, ghl_eos);
+  ghl_abort_if_error(err);
 
   for(int k=0; k<cctk_lsh[2]; k++) {
     for(int j=0; j<cctk_lsh[1]; j++) {

--- a/GRHayLIDX/src/BetaEquilibrium.cxx
+++ b/GRHayLIDX/src/BetaEquilibrium.cxx
@@ -16,7 +16,9 @@ void GRHayLIDX_BetaEquilibrium( CCTK_ARGUMENTS ) {
 
   CHECK_PARAMETER(beq_temperature);
 
-  ghl_tabulated_compute_Ye_of_rho_beq_constant_T(beq_temperature, ghl_eos);
+  ghl_error_codes_t err = ghl_success;
+  err = ghl_tabulated_compute_Ye_of_rho_beq_constant_T(beq_temperature, ghl_eos);
+  ghl_abort_if_error(err);
 
   const Loop::GF3D2layout layout(cctkGH, {1, 1, 1});
 

--- a/GRHayLIDX/src/BetaEquilibrium.cxx
+++ b/GRHayLIDX/src/BetaEquilibrium.cxx
@@ -34,10 +34,18 @@ void GRHayLIDX_BetaEquilibrium( CCTK_ARGUMENTS ) {
       temperature(index) = ghl_eos->T_atm;
     } else {
       const double tempL = beq_temperature;
-      const double YeL   = ghl_tabulated_compute_Ye_from_rho(ghl_eos, rhoL);
+      double pressL = 0.0, epsL = 0.0, YeL = 0.0;
+      ghl_error_codes_t err = ghl_success;
 
-      double pressL, epsL;
-      ghl_tabulated_compute_P_eps_from_T(ghl_eos, rhoL, YeL, tempL, &pressL, &epsL);
+      err = ghl_tabulated_compute_Ye_from_rho(ghl_eos, rhoL, &YeL);
+      if(err != ghl_success) {
+        CCTK_ERROR("ghl_tabulated_compute_Ye_from_rho failed.");
+      }
+
+      err = ghl_tabulated_compute_P_eps_from_T(ghl_eos, rhoL, YeL, tempL, &pressL, &epsL);
+      if(err != ghl_success) {
+        CCTK_ERROR("ghl_tabulated_compute_P_eps_from_T failed.");
+      }
 
       press      (index) = pressL;
       eps        (index) = epsL;

--- a/IllinoisGRMHD/src/Hybrid/calculate_fluxes_rhs.c
+++ b/IllinoisGRMHD/src/Hybrid/calculate_fluxes_rhs.c
@@ -180,13 +180,11 @@ void IllinoisGRMHD_hybrid_calculate_flux_dir_rhs(
         prims_l.vU[1] = vel_l[1][index];
         prims_l.vU[2] = vel_l[2][index];
 
-        bool speed_limited;
+        bool speed_limited = false;
         ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
         error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         ghl_conservative_quantities cons_fluxes;
         calculate_characteristic_speed(&prims_r, &prims_l, ghl_eos, &ADM_metric_face, &cmin[index], &cmax[index]);

--- a/IllinoisGRMHD/src/Hybrid/conservs_to_prims.c
+++ b/IllinoisGRMHD/src/Hybrid/conservs_to_prims.c
@@ -218,8 +218,7 @@ void IllinoisGRMHD_hybrid_conservs_to_prims(CCTK_ARGUMENTS) {
         // Enforce limits on primitive variables and recompute conservatives.
         error = ghl_enforce_primitive_limits_and_compute_u0(
               ghl_params, ghl_eos, &ADM_metric, &prims, &diagnostics.speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         rho[index]   = prims.rho;
         press[index] = prims.press;

--- a/IllinoisGRMHD/src/Hybrid/evaluate_sources_rhs.c
+++ b/IllinoisGRMHD/src/Hybrid/evaluate_sources_rhs.c
@@ -51,10 +51,9 @@ void IllinoisGRMHD_hybrid_evaluate_sources_rhs(CCTK_ARGUMENTS) {
         prims.BU[1] = By_center[index];
         prims.BU[2] = Bz_center[index];
 
-        bool speed_limited;
+        bool speed_limited = false;
         ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         ghl_metric_quantities ADM_metric_derivs_x;
         IllinoisGRMHD_compute_metric_derivs(

--- a/IllinoisGRMHD/src/Hybrid/hydro_outer_boundaries.c
+++ b/IllinoisGRMHD/src/Hybrid/hydro_outer_boundaries.c
@@ -200,15 +200,13 @@ void IllinoisGRMHD_hybrid_enforce_primitive_limits_and_compute_conservs(const cG
   ghl_ADM_aux_quantities metric_aux;
   ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
 
-  bool speed_limited;
+  bool speed_limited = false;
   ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
         ghl_params, ghl_eos, &ADM_metric, prims, &speed_limited);
-  if(error)
-    ghl_read_error_codes(error);
+  ghl_abort_if_error(error);
 
   ghl_conservative_quantities cons;
-  ghl_compute_conservs(
-        &ADM_metric, &metric_aux, prims, &cons);
+  ghl_compute_conservs(&ADM_metric, &metric_aux, prims, &cons);
 
   rho[index]   = prims->rho;
   press[index] = prims->press;

--- a/IllinoisGRMHD/src/Hybrid/prims_to_conservs.c
+++ b/IllinoisGRMHD/src/Hybrid/prims_to_conservs.c
@@ -35,15 +35,13 @@ void IllinoisGRMHD_hybrid_prims_to_conservs(CCTK_ARGUMENTS) {
         prims.BU[1] = By_center[index];
         prims.BU[2] = Bz_center[index];
 
-        bool speed_limited; 
+        bool speed_limited = false;
         const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
               ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         ghl_conservative_quantities cons;
-        ghl_compute_conservs(
-              &ADM_metric, &metric_aux, &prims, &cons);
+        ghl_compute_conservs(&ADM_metric, &metric_aux, &prims, &cons);
 
         rho[index]   = prims.rho;
         press[index] = prims.press;

--- a/IllinoisGRMHD/src/HybridEntropy/calculate_fluxes_rhs.c
+++ b/IllinoisGRMHD/src/HybridEntropy/calculate_fluxes_rhs.c
@@ -182,13 +182,12 @@ void IllinoisGRMHD_hybrid_entropy_calculate_flux_dir_rhs(
         prims_l.vU[1] = vel_l[1][index];
         prims_l.vU[2] = vel_l[2][index];
 
-        bool speed_limited;
+        bool speed_limited = false;
         ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
+
         error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         ghl_conservative_quantities cons_fluxes;
         calculate_characteristic_speed(&prims_r, &prims_l, ghl_eos, &ADM_metric_face, &cmin[index], &cmax[index]);

--- a/IllinoisGRMHD/src/HybridEntropy/conservs_to_prims.c
+++ b/IllinoisGRMHD/src/HybridEntropy/conservs_to_prims.c
@@ -229,8 +229,7 @@ void IllinoisGRMHD_hybrid_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
         // Enforce limits on primitive variables and recompute conservatives.
         error = ghl_enforce_primitive_limits_and_compute_u0(
               ghl_params, ghl_eos, &ADM_metric, &prims, &diagnostics.speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         rho[index]     = prims.rho;
         press[index]   = prims.press;

--- a/IllinoisGRMHD/src/HybridEntropy/evaluate_sources_rhs.c
+++ b/IllinoisGRMHD/src/HybridEntropy/evaluate_sources_rhs.c
@@ -53,10 +53,9 @@ void IllinoisGRMHD_hybrid_entropy_evaluate_sources_rhs(CCTK_ARGUMENTS) {
         prims.BU[2] = Bz_center[index];
         prims.entropy = entropy[index];
 
-        bool speed_limited;
+        bool speed_limited = false;
         ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         ghl_metric_quantities ADM_metric_derivs_x;
         IllinoisGRMHD_compute_metric_derivs(

--- a/IllinoisGRMHD/src/HybridEntropy/hydro_outer_boundaries.c
+++ b/IllinoisGRMHD/src/HybridEntropy/hydro_outer_boundaries.c
@@ -206,15 +206,13 @@ void IllinoisGRMHD_hybrid_entropy_enforce_primitive_limits_and_compute_conservs(
   ghl_ADM_aux_quantities metric_aux;
   ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
 
-  bool speed_limited;
+  bool speed_limited = false;
   ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
         ghl_params, ghl_eos, &ADM_metric, prims, &speed_limited);
-  if(error)
-    ghl_read_error_codes(error);
+  ghl_abort_if_error(error);
 
   ghl_conservative_quantities cons;
-  ghl_compute_conservs(
-        &ADM_metric, &metric_aux, prims, &cons);
+  ghl_compute_conservs(&ADM_metric, &metric_aux, prims, &cons);
 
   rho[index]     = prims->rho;
   press[index]   = prims->press;

--- a/IllinoisGRMHD/src/HybridEntropy/prims_to_conservs.c
+++ b/IllinoisGRMHD/src/HybridEntropy/prims_to_conservs.c
@@ -36,15 +36,13 @@ void IllinoisGRMHD_hybrid_entropy_prims_to_conservs(CCTK_ARGUMENTS) {
         prims.BU[2]   = Bz_center[index];
         prims.entropy = entropy[index];
 
-        bool speed_limited; 
+        bool speed_limited = false;
         const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
               ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         ghl_conservative_quantities cons;
-        ghl_compute_conservs(
-              &ADM_metric, &metric_aux, &prims, &cons);
+        ghl_compute_conservs(&ADM_metric, &metric_aux, &prims, &cons);
 
         rho[index]     = prims.rho;
         press[index]   = prims.press;

--- a/IllinoisGRMHD/src/Tabulated/calculate_fluxes_rhs.c
+++ b/IllinoisGRMHD/src/Tabulated/calculate_fluxes_rhs.c
@@ -175,13 +175,12 @@ void IllinoisGRMHD_tabulated_calculate_flux_dir_rhs(
 
         prims_r.temperature = prims_l.temperature = temperature[index];
 
-        bool speed_limited;
+        bool speed_limited = false;
         ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
+
         error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         // We must now compute eps and T
         ghl_tabulated_enforce_bounds_rho_Ye_P(ghl_eos, &prims_r.rho, &prims_r.Y_e, &prims_r.press);

--- a/IllinoisGRMHD/src/Tabulated/conservs_to_prims.c
+++ b/IllinoisGRMHD/src/Tabulated/conservs_to_prims.c
@@ -196,8 +196,7 @@ void IllinoisGRMHD_tabulated_conservs_to_prims(CCTK_ARGUMENTS) {
         // Enforce limits on primitive variables and recompute conservatives.
         error = ghl_enforce_primitive_limits_and_compute_u0(
               ghl_params, ghl_eos, &ADM_metric, &prims, &diagnostics.speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         rho[index]         = prims.rho;
         press[index]       = prims.press;

--- a/IllinoisGRMHD/src/Tabulated/evaluate_sources_rhs.c
+++ b/IllinoisGRMHD/src/Tabulated/evaluate_sources_rhs.c
@@ -54,10 +54,9 @@ void IllinoisGRMHD_tabulated_evaluate_sources_rhs(CCTK_ARGUMENTS) {
         prims.Y_e         = Y_e[index];
         prims.temperature = temperature[index];
 
-        bool speed_limited;
+        bool speed_limited = false;
         ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         ghl_metric_quantities ADM_metric_derivs_x;
         IllinoisGRMHD_compute_metric_derivs(

--- a/IllinoisGRMHD/src/Tabulated/hydro_outer_boundaries.c
+++ b/IllinoisGRMHD/src/Tabulated/hydro_outer_boundaries.c
@@ -212,15 +212,13 @@ void IllinoisGRMHD_tabulated_enforce_primitive_limits_and_compute_conservs(const
   ghl_ADM_aux_quantities metric_aux;
   ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
 
-  bool speed_limited;
+  bool speed_limited = false;
   ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
         ghl_params, ghl_eos, &ADM_metric, prims, &speed_limited);
-  if(error)
-    ghl_read_error_codes(error);
+  ghl_abort_if_error(error);
 
   ghl_conservative_quantities cons;
-  ghl_compute_conservs(
-        &ADM_metric, &metric_aux, prims, &cons);
+  ghl_compute_conservs(&ADM_metric, &metric_aux, prims, &cons);
 
   rho[index]         = prims->rho;
   press[index]       = prims->press;

--- a/IllinoisGRMHD/src/Tabulated/prims_to_conservs.c
+++ b/IllinoisGRMHD/src/Tabulated/prims_to_conservs.c
@@ -37,15 +37,13 @@ void IllinoisGRMHD_tabulated_prims_to_conservs(CCTK_ARGUMENTS) {
         prims.Y_e         = Y_e[index];
         prims.temperature = temperature[index];
 
-        bool speed_limited; 
+        bool speed_limited = false;
         const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
               ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         ghl_conservative_quantities cons;
-        ghl_compute_conservs(
-              &ADM_metric, &metric_aux, &prims, &cons);
+        ghl_compute_conservs(&ADM_metric, &metric_aux, &prims, &cons);
 
         rho[index]         = prims.rho;
         press[index]       = prims.press;

--- a/IllinoisGRMHD/src/TabulatedEntropy/calculate_fluxes_rhs.c
+++ b/IllinoisGRMHD/src/TabulatedEntropy/calculate_fluxes_rhs.c
@@ -177,13 +177,12 @@ void IllinoisGRMHD_tabulated_entropy_calculate_flux_dir_rhs(
 
         prims_r.temperature = prims_l.temperature = temperature[index];
 
-        bool speed_limited;
+        bool speed_limited = false;
         ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_r, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
+
         error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric_face, &prims_l, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         // We must now compute eps and T
         ghl_tabulated_enforce_bounds_rho_Ye_P(ghl_eos, &prims_r.rho, &prims_r.Y_e, &prims_r.press);

--- a/IllinoisGRMHD/src/TabulatedEntropy/conservs_to_prims.c
+++ b/IllinoisGRMHD/src/TabulatedEntropy/conservs_to_prims.c
@@ -202,8 +202,7 @@ void IllinoisGRMHD_tabulated_entropy_conservs_to_prims(CCTK_ARGUMENTS) {
         // Enforce limits on primitive variables and recompute conservatives.
         error = ghl_enforce_primitive_limits_and_compute_u0(
               ghl_params, ghl_eos, &ADM_metric, &prims, &diagnostics.speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         rho[index]         = prims.rho;
         press[index]       = prims.press;

--- a/IllinoisGRMHD/src/TabulatedEntropy/evaluate_sources_rhs.c
+++ b/IllinoisGRMHD/src/TabulatedEntropy/evaluate_sources_rhs.c
@@ -56,10 +56,9 @@ void IllinoisGRMHD_tabulated_entropy_evaluate_sources_rhs(CCTK_ARGUMENTS) {
         prims.Y_e         = Y_e[index];
         prims.temperature = temperature[index];
 
-        bool speed_limited;
+        bool speed_limited = false;
         ghl_error_codes_t error = ghl_limit_v_and_compute_u0(ghl_params, &ADM_metric, &prims, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         ghl_metric_quantities ADM_metric_derivs_x;
         IllinoisGRMHD_compute_metric_derivs(

--- a/IllinoisGRMHD/src/TabulatedEntropy/hydro_outer_boundaries.c
+++ b/IllinoisGRMHD/src/TabulatedEntropy/hydro_outer_boundaries.c
@@ -218,15 +218,13 @@ void IllinoisGRMHD_tabulated_entropy_enforce_primitive_limits_and_compute_conser
   ghl_ADM_aux_quantities metric_aux;
   ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
 
-  bool speed_limited;
+  bool speed_limited = false;
   ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
         ghl_params, ghl_eos, &ADM_metric, prims, &speed_limited);
-  if(error)
-    ghl_read_error_codes(error);
+  ghl_abort_if_error(error);
 
   ghl_conservative_quantities cons;
-  ghl_compute_conservs(
-        &ADM_metric, &metric_aux, prims, &cons);
+  ghl_compute_conservs(&ADM_metric, &metric_aux, prims, &cons);
 
   rho[index]         = prims->rho;
   press[index]       = prims->press;

--- a/IllinoisGRMHD/src/TabulatedEntropy/prims_to_conservs.c
+++ b/IllinoisGRMHD/src/TabulatedEntropy/prims_to_conservs.c
@@ -38,15 +38,13 @@ void IllinoisGRMHD_tabulated_entropy_prims_to_conservs(CCTK_ARGUMENTS) {
         prims.Y_e         = Y_e[index];
         prims.temperature = temperature[index];
 
-        bool speed_limited; 
+        bool speed_limited = false;
         const ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
               ghl_params, ghl_eos, &ADM_metric, &prims, &speed_limited);
-        if(error)
-          ghl_read_error_codes(error);
+        ghl_abort_if_error(error);
 
         ghl_conservative_quantities cons;
-        ghl_compute_conservs(
-              &ADM_metric, &metric_aux, &prims, &cons);
+        ghl_compute_conservs(&ADM_metric, &metric_aux, &prims, &cons);
 
         rho[index]         = prims.rho;
         press[index]       = prims.press;


### PR DESCRIPTION
This PR updates thorns in `GRHayLET` to use the new `GRHayL` API introduced by [PR #92](https://github.com/GRHayL/GRHayL/pull/92). It correctly replaces calls to:
* `ghl_read_error_code()` with the new `ghl_abort_if_error()`; and
* beta-equilibrium EOS functions, which now return an error code instead of the interpolation value.